### PR TITLE
[develop] Dockerized LabKey 17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ This project is set up assuming the following architecture:
   
 In order to ease that setup, the repo contains a Dockerfile for a "labkey" image and a docker-compose that sets up the system with the appropriate volumes mounted for local development. To run it, do the following:
 
-  1. Execute `:docker:build --no-daemon` **from the command line/terminal**. You will need to provide credentials for the LabKey TeamCity server in order to download the build. You will only need to do this once, to build and store the Docker image.
+  1. Set the following variables in your `~/.gradle/gradle.properties` file:
+      ```gradle
+      labkeyTeamcityUsername=<your username>
+      labkeyTeamcityPassword=<your password>
+      ```
+  1. Execute `:docker:build`. You will only need to do this once, to build and store the Docker image.
   1. Execute `:docker:up` to start the server. This will look at the `docker-compose.yml` file in the docker folder and will start the LabKey image built by the previous step as well as a default postgres database container, hooking the two together and exposing LabKey at `http://localhost:8080`. Any modules built using `:deployModule` will be automatically loaded by LabKey, due to the `build/modules` folder being mounted as a volume in the LabKey container.
   1. Execute `:docker:down` to bring the server down. This will shut down both LabKey and postgres.
   

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -8,7 +8,7 @@ idea.module {
 task("buildLabkey", group: "Docker", type: Exec, description: "Generates the LabKey docker image") {
     workingDir "${project.rootDir}/docker/labkey"
     executable "docker"
-    args "build", ".", "-t", "wnprcehr/labkey:15.2"
+    args "build", "--build-arg", "LABKEY_TEAMCITY_USERNAME=${labkeyTeamcityUsername}", "--build-arg", "LABKEY_TEAMCITY_PASSWORD=${labkeyTeamcityPassword}", ".", "-t", "wnprcehr/labkey:17.2"
 }
 
 task("buildMonit", group: "Docker", type: Exec, description: "Generates the Monit docker image") {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   postgres:
-    image: postgres:9.2
+    image: postgres:9.4
     volumes:
       - "${PG_DATA_DIR}:/var/lib/postgresql/data"
     ports:
@@ -28,7 +28,7 @@ services:
       - "1025:1025"
 
   labkey:
-    image: wnprcehr/labkey:15.2
+    image: wnprcehr/labkey:17.2
     depends_on:
       - "mailserver"
       - "postgres"

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -1,4 +1,22 @@
 # -----------------------------------------------------------------------------
+# HELPER IMAGE (to download LabKey)
+
+FROM alpine:latest as download
+
+ARG LABKEY_TEAMCITY_PASSWORD
+ARG LABKEY_TEAMCITY_USERNAME
+
+ENV LABKEY_TEAMCITY_CONFIG LabKey_172Modules_Premium_Installers
+ENV LABKEY_VERSION 17.2
+
+WORKDIR /tmp/labkey
+
+RUN apk add --no-cache wget tar ca-certificates && update-ca-certificates
+RUN X="`wget -qO- --http-user="${LABKEY_TEAMCITY_USERNAME}" --http-password="${LABKEY_TEAMCITY_PASSWORD}" https://teamcity.labkey.org/httpAuth/app/rest/buildTypes/${LABKEY_TEAMCITY_CONFIG}/builds/status:success/number`" \
+ && wget -qO- --http-user="${LABKEY_TEAMCITY_USERNAME}" --http-password="${LABKEY_TEAMCITY_PASSWORD}" https://teamcity.labkey.org/httpAuth/app/rest/builds/number:${X}/artifacts/content/wisc/Labkey${LABKEY_VERSION}-${X%%\.[[:digit:]]*}-UWisc-bin.tar.gz \
+  | tar -xz --strip-components=1
+
+# -----------------------------------------------------------------------------
 # MAIN IMAGE BUILD DEFINITION
 
 FROM store/oracle/serverjre:8
@@ -7,20 +25,15 @@ ENV CATALINA_HOME /usr/local/tomcat
 WORKDIR $CATALINA_HOME
 
 # download and untar tomcat
-ENV TOMCAT_VERSION 7.0.82
+ENV TOMCAT_VERSION 8.5.23
 RUN yum -y -q install wget tar gzip \
  && wget -qO- http://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION%%\.[[:digit:]]*}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz \
   | tar -xz --strip-components=1 \
  && chmod -R 755 .
 
-# download and untar LabKey
+# copy in LabKey from the other stage of the build and copy in the jars to tomcat
 ENV LABKEY_HOME /usr/local/labkey
-ENV LABKEY_TEAMCITY_CONFIG LabkeyModules152_Installers
-ENV LABKEY_VERSION 15.2
-RUN mkdir -p $LABKEY_HOME
-RUN LABKEY_TEAMCITY_BUILD="`wget -qO- https://teamcity.labkey.org/guestAuth/app/rest/buildTypes/${LABKEY_TEAMCITY_CONFIG}/builds/status:success/number`" \
- && wget -qO- https://teamcity.labkey.org/guestAuth/app/rest/builds/number:${LABKEY_TEAMCITY_BUILD}/artifacts/content/wisc/LabKey${LABKEY_VERSION}-${LABKEY_TEAMCITY_BUILD}-UWisc-bin.tar.gz \
-  | tar -xz -C $LABKEY_HOME --strip-components=1
+COPY --from=download /tmp/labkey $LABKEY_HOME
 RUN cp $LABKEY_HOME/tomcat-lib/*.jar lib
 
 # add the session path to the tomcat config


### PR DESCRIPTION
Updated the Docker files and the build.gradle so we can create a Docker setup using a pre-built copy of LabKey 17.2 from the TeamCity server.