### PR TITLE
[master] limiting postgres login access

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - "${PG_CONF_FILE}:/var/lib/postgresql/data/postgresql.conf"
       - "${PG_DATA_DIR}:/var/lib/postgresql/data"
+      - "${PG_HBA_FILE}:/var/lib/postgresql/data/pg_hba.conf"
       - "${PG_LOG_DIR}:/var/lib/postgresql/data/pg_log"
     ports:
       - "9081:5432"
@@ -14,15 +15,15 @@ services:
     environment:
       TZ: America/Chicago
  
-  pgbadger:
-    image: wnprcehr/pgbadger:latest
-    depends_on:
-      - "postgres"
-    volumes:
-      - "${PG_LOG_DIR}:/var/log/postgresql"
-      - "${PG_REPORTS_DIR}:/var/www/pg_reports"
-    environment:
-      TZ: America/Chicago
+#  pgbadger:
+#    image: wnprcehr/pgbadger:latest
+#    depends_on:
+#      - "postgres"
+#    volumes:
+#      - "${PG_LOG_DIR}:/var/log/postgresql"
+#      - "${PG_REPORTS_DIR}:/var/www/pg_reports"
+#    environment:
+#      TZ: America/Chicago
 
   mailcatcher:
     image: schickling/mailcatcher
@@ -40,7 +41,7 @@ services:
       - "1025"
 
   labkey:
-    image: wnprcehr/labkey:15.2
+    image: wnprcehr/labkey:15.2a1
     depends_on:
       - "mailserver"
       - "postgres"
@@ -63,7 +64,7 @@ services:
     image: nginx:1.13.0
     depends_on:
       - "labkey"
-      - "pgbadger"
+#      - "pgbadger"
     volumes:
       - "${NGINX_CLIENT_CER_FILE}:/usr/local/ssl/client-ca.pem"
       - "${NGINX_CLIENT_CRL_FILE}:/usr/local/ssl/crl.pem"
@@ -92,18 +93,18 @@ services:
       LK_BASE_URL:
       TZ: America/Chicago
 
-  monit:
-    image: wnprcehr/monit:latest
-    depends_on:
-      - "mailserver"
-      - "postgres"
-    links:
-      - mailserver:mailserver-container
-      - postgres
-    volumes:
-      - "${MONIT_CONFIG_FILE}:/etc/monit/monitrc"
-      - "${MONIT_HOST_BACKUP_DIR}:/host/backup"
-      - "${MONIT_HOST_ROOT_DIR}:/host"
-      - "${MONIT_LOG_DIR}:/etc/monit/logs"
-    environment:
-      TZ: America/Chicago
+#  monit:
+#    image: wnprcehr/monit:latest
+#    depends_on:
+#      - "mailserver"
+#      - "postgres"
+#    links:
+#      - mailserver:mailserver-container
+#      - postgres
+#    volumes:
+#      - "${MONIT_CONFIG_FILE}:/etc/monit/monitrc"
+#      - "${MONIT_HOST_BACKUP_DIR}:/host/backup"
+#      - "${MONIT_HOST_ROOT_DIR}:/host"
+#      - "${MONIT_LOG_DIR}:/etc/monit/logs"
+#    environment:
+#      TZ: America/Chicago

--- a/docker/postgres/pg_hba.conf
+++ b/docker/postgres/pg_hba.conf
@@ -1,0 +1,92 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTIONS]
+# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# plain TCP/IP socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "gss", "sspi",
+# "krb5", "ident", "peer", "pam", "ldap", "radius" or "cert".  Note that
+# "password" sends passwords in clear text; "md5" is preferred since
+# it sends encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+# CAUTION: Configuring the system for local "trust" authentication
+# allows any local user to connect as any PostgreSQL user, including
+# the database superuser.  If you do not trust all your local users,
+# use another authentication method.
+
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# connections from the other docker containers
+host	all		all		172.18.0.0/16		trust
+# connections from other machines on campus
+host	all		all		128.104.0.0/16		password


### PR DESCRIPTION
Updated the pg_hba.conf to only allow 'trust' from within the docker-compose network and only allow password-based connections from a well-known UW subnet