### PR TITLE
[master] updating the Debian repo version for ehrcron

### DIFF
--- a/docker/ehrcron/Dockerfile
+++ b/docker/ehrcron/Dockerfile
@@ -11,7 +11,7 @@ RUN cpanm LabKey::Query         \
           Log::Rolling
 
 # Add the apt repo for PostgreSQL so we can install the client package
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 # The gettext package contains the envsubst command needed for the run command of this image.


### PR DESCRIPTION
This updates the Debian repo for PostgreSQL to use the one for stretch (9.x) rather than jessie (8.x)