### PR TITLE
[master] downgraded to Rlabkey 2.1.127 to match our old server

### DIFF
--- a/docker/labkey/.dockerignore
+++ b/docker/labkey/.dockerignore
@@ -2,6 +2,7 @@
 *
 
 # whitelist the following files:
+!install.r
 !netrc
 !pipelineConfig.xml
 !public-yum-ol7.repo

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -66,14 +66,8 @@ COPY pipelineConfig.xml /usr/local/labkey/config/config-server/pipelineConfig.xm
 EXPOSE 8080
 
 # install the necessary R scripts
-RUN mkdir -p /usr/share/doc/R-3.2.0/html \
- && Rscript -e "install.packages('quadprog', repos='http://cran.us.r-project.org')" \
- && Rscript -e "install.packages('pedigree', repos='http://cran.us.r-project.org')" \
- && Rscript -e "install.packages('Matrix',   repos='http://cran.us.r-project.org')" \
- && Rscript -e "install.packages('RCurl',    repos='http://cran.us.r-project.org')" \
- && Rscript -e "install.packages('Rlabkey',  repos='http://cran.us.r-project.org')" \
- && Rscript -e "install.packages('kinship2', repos='http://cran.us.r-project.org')" \
- && Rscript -e "install.packages('getopt',   repos='http://cran.us.r-project.org')"
+COPY install.r /tmp/install.r
+RUN mkdir -p /usr/share/doc/R-3.2.0/html && Rscript /tmp/install.r
 
 # copy over the .netrc template file
 COPY netrc /root/netrc.template

--- a/docker/labkey/install.r
+++ b/docker/labkey/install.r
@@ -1,0 +1,12 @@
+install.packages('devtools', repos='http://cran.us.r-project.org')
+install.packages('quadprog', repos='http://cran.us.r-project.org')
+install.packages('pedigree', repos='http://cran.us.r-project.org')
+install.packages('Matrix',   repos='http://cran.us.r-project.org')
+install.packages('RCurl',    repos='http://cran.us.r-project.org')
+install.packages('kinship2', repos='http://cran.us.r-project.org')
+install.packages('getopt',   repos='http://cran.us.r-project.org')
+install.packages('rjson',    repos='http://cran.us.r-project.org')
+
+require('devtools')
+install_version('Rlabkey', version='2.1.127', repos='http://cran.us.r-project.org')
+


### PR DESCRIPTION
This change downgrades our Rlabkey version 2.1.127 to correspond with LabKey 15.2. That was the version that was on the old EHR server.

Also moves the Rscript commands to a .r file so they don't pollute the Dockerfile quite so much.

>NOTE: We probably do **not** want this for develop and above, since 17.2 should be compatible with the newer versions of the R library.