### PR TITLE
Misc Fixes from wnprc18.3_master to release19.2-SNAPSHOT

### DIFF
--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -394,9 +394,6 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         verifyChargeSummary("Misc. Charges", 1);
         verifyChargeSummary("Per Diems", 1);
 
-        clickAndWait(Locator.tagWithAttributeContaining("a", "href", "queryName=project").findElement(getDriver()));
-        DataRegionTable table = new DataRegionTable("query", getDriver());
-        assertEquals("Wrong number of rows in project", 2, table.getDataRowCount());
         goBack(WAIT_FOR_PAGE);
     }
 

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -394,7 +394,6 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         verifyChargeSummary("Misc. Charges", 1);
         verifyChargeSummary("Per Diems", 1);
 
-        assertTextPresent("There are 2 active WNPRC project(s) with account(s) that are not accepting charges.");
         clickAndWait(Locator.tagWithAttributeContaining("a", "href", "queryName=project").findElement(getDriver()));
         DataRegionTable table = new DataRegionTable("query", getDriver());
         assertEquals("Wrong number of rows in project", 2, table.getDataRowCount());

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -767,6 +767,9 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
     {
         List<String> expectedColumns = Arrays.asList(
                 "alias",
+                "isActive",
+                "isAcceptingCharges",
+                "gencredits",
                 "grantNumber",
                 "tier_rate",
                 "type",
@@ -793,7 +796,6 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
                 "order_cutoff",
                 "successor_account",
                 "predecessor_account",
-                "gencredits",
                 "mds_number"
         );
 

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -982,7 +982,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
 
     private void testInvoicedItems()
     {
-        testReports("All Invoiced Items", 7, "test2312318","640991" , "$19.50", "$15.00",
+        testReports("Invoiced Items", 7, "test2312318","640991" , "$19.50", "$15.00",
                 "Blood draws - Additional Tubes", "Per diems", "Misc. Fees", "vaccine supplies", "$195.00");
     }
 

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -913,7 +913,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         testExpectedRowCount(TIER_RATES_NUM_ROWS);
 
         //upload Grant Accounts
-        importBulkDataFromFile(ALIASES_TSV, "Grant Accounts", ALIASES_NUM_ROWS);
+        importBulkDataFromFile(ALIASES_TSV, "Grant Accounts - ALL", ALIASES_NUM_ROWS);
         testExpectedRowCount(ALIASES_NUM_ROWS);
 
         //upload Chargeable Item Categories

--- a/wnprc_billing/resources/queries/ehr_billing/aliases.js
+++ b/wnprc_billing/resources/queries/ehr_billing/aliases.js
@@ -8,4 +8,8 @@ require("ehr/triggers").initScript(this);
 
 function onUpsert(helper, scriptErrors, row, oldRow){
    row.alias = row.alias.toLowerCase();
+
+   if (!row.isAcceptingCharges) {
+      row.isAcceptingCharges = true; //true by default
+   }
 }

--- a/wnprc_billing/resources/queries/ehr_billing/aliases.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/aliases.query.xml
@@ -2,12 +2,19 @@
     <metadata>
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="aliases" tableDbType="TABLE" useColumnOrder="true">
-            <tableTitle>Grant Accounts</tableTitle>
+                <javaCustomizer class="org.labkey.ehr_billing.table.EHR_BillingCustomizer" />
+                <tableTitle>Grant Accounts</tableTitle>
             <auditLogging>DETAILED</auditLogging>
             <columns>
                 <column columnName="alias">
                     <columnTitle>Account Number</columnTitle>
                     <nullable>false</nullable>
+                </column>
+                <column columnName="isAcceptingCharges">
+                    <formatString>Y;N;</formatString>
+                </column>
+                <column columnName="gencredits">
+                    <formatString>Y;N;</formatString>
                 </column>
                 <column columnName="projectNumber">
                     <columnTitle>Project Number</columnTitle>
@@ -80,7 +87,6 @@
                 <column columnName="order_cutoff"/>
                 <column columnName="successor_account"/>
                 <column columnName="predecessor_account"/>
-                <column columnName="gencredits"/>
                 <column columnName="mds_number"/>
                 <column columnName="faRate">
                     <isHidden>true</isHidden>

--- a/wnprc_billing/resources/queries/ehr_billing/aliases.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/aliases.query.xml
@@ -7,12 +7,14 @@
             <columns>
                 <column columnName="alias">
                     <columnTitle>Account Number</columnTitle>
+                    <nullable>false</nullable>
                 </column>
                 <column columnName="projectNumber">
                     <columnTitle>Project Number</columnTitle>
                 </column>
                 <column columnName="grantNumber">
                     <columnTitle>Grant Number</columnTitle>
+                    <nullable>false</nullable>
                 </column>
                 <column columnName="tier_rate">
                     <nullable>false</nullable>
@@ -23,7 +25,11 @@
                         <fkDisplayColumnName>tierRate</fkDisplayColumnName>
                     </fk>
                 </column>
-                <column columnName="type"/>
+                <column columnName="type">
+                    <nullable>false</nullable>
+                    <description>Expected values: internal_uw or external</description>
+                    <defaultValue>internal_uw</defaultValue>
+                </column>
                 <column columnName="budgetStartDate">
                     <columnTitle>Current Service Begin</columnTitle>
                 </column>

--- a/wnprc_billing/resources/queries/ehr_billing/aliases.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/aliases.query.xml
@@ -12,6 +12,7 @@
                 </column>
                 <column columnName="isAcceptingCharges">
                     <formatString>Y;N;</formatString>
+                    <defaultValue>1</defaultValue>
                 </column>
                 <column columnName="gencredits">
                     <formatString>Y;N;</formatString>

--- a/wnprc_billing/resources/queries/ehr_billing/aliases/.qview.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/aliases/.qview.xml
@@ -1,6 +1,9 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
     <columns>
         <column name="alias"/>
+        <column name="isActive"/>
+        <column name="isAcceptingCharges"/>
+        <column name="gencredits"/>
         <column name="grantNumber"/>
         <column name="tier_rate"/>
         <column name="type"/>
@@ -27,7 +30,6 @@
         <column name="order_cutoff"/>
         <column name="successor_account"/>
         <column name="predecessor_account"/>
-        <column name="gencredits"/>
         <column name="mds_number"/>
     </columns>
     <sorts>

--- a/wnprc_billing/resources/queries/ehr_billing/aliases/Active Grant Accounts.qview.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/aliases/Active Grant Accounts.qview.xml
@@ -1,0 +1,8 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+    <sorts>
+        <sort column="alias" descending="false"/>
+    </sorts>
+    <filters>
+        <filter column="isActive" operator="eq" value="Y"/>
+    </filters>
+</customView>

--- a/wnprc_billing/resources/queries/ehr_billing/chargeableItems.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/chargeableItems.query.xml
@@ -13,6 +13,7 @@
                         <description>PK from the WNPRC's current finance system (from table charges.rate_schedule.Id)</description>
                     </column>
                     <column columnName="departmentCode">
+                        <nullable>false</nullable>
                         <columnTitle>Group Name</columnTitle>
                         <fk>
                             <fkDbSchema>ehr_billing</fkDbSchema>

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceExternaLastRun/.qview.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceExternaLastRun/.qview.xml
@@ -1,0 +1,31 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+    <columns>
+        <column name="invoiceNumber"/>
+        <column name="invoiceRunId"/>
+        <column name="invoiceRunId/billingPeriodStart"/>
+        <column name="invoiceRunId/billingPeriodEnd"/>
+        <column name="BillingRunDate"/>
+        <column name="accountNumber"/>
+        <column name="accountNumber/type"/>
+        <column name="accountNumber/po_number"/>
+        <column name="accountNumber/contact_name"/>
+        <column name="accountNumber/address"/>
+        <column name="invoiceAmount"/>
+        <column name="viewPdf">
+            <properties>
+                <property name="columnTitle" value="View PDF"/>
+            </properties>
+        </column>
+        <column name="downloadPDF">
+            <properties>
+                <property name="columnTitle" value="Download PDF"/>
+            </properties>
+        </column>
+        <column name="summarizedPDF">
+            <properties>
+                <property name="columnTitle" value="Summarized PDF"/>
+            </properties>
+        </column>
+    </columns>
+    <filters></filters>
+</customView>

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceExternalLastRun.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceExternalLastRun.query.xml
@@ -1,0 +1,33 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="invoiceExternalLastRun" tableDbType="NOT_IN_DB">
+                <javaCustomizer class = "org.labkey.wnprc_billing.WNPRC_InvoiceCustomizer"/>
+                <tableTitle>External Invoices for the Last Billing Run</tableTitle>
+                <buttonBarOptions position="top" includeStandardButtons="true">
+                    <item text="Download Invoices" insertPosition="end" requiresSelection="true">
+                        <target method="POST">wnprc_billing/DownloadInvoices.view?</target>
+                    </item>
+                </buttonBarOptions>
+                <columns>
+                    <column columnName="rowId"/>
+                    <column columnName="invoiceNumber">
+                        <isKeyField>true</isKeyField> <!--pk needs to be set on a grid for the requiresSelection to work in above buttonBarOptions item -->
+                    </column>
+                    <column columnName="invoiceRunId"/>
+                    <column columnName="accountNumber">
+                        <fk>
+                            <fkDbSchema>ehr_billing</fkDbSchema>
+                            <fkTable>aliases</fkTable>
+                            <fkColumnName>alias</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="invoiceSentOn"/>
+                    <column columnName="invoiceAmount">
+                        <formatString>$###,##0.00</formatString>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceExternalLastRun.sql
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceExternalLastRun.sql
@@ -1,4 +1,4 @@
-SELECT
+SELECT DISTINCT
   invExternal.rowId,
   invExternal.invoiceNumber,
   invExternal.invoiceRunId,
@@ -12,17 +12,3 @@ SELECT
   invExternal.address,
   invExternal.invoiceAmount
 FROM ehr_billing.invoiceExternal invExternal WHERE invExternal.invoiceRunId =(SELECT max(invoiceRunId) from ehr_billing.invoiceExternal)
-
-GROUP BY
-         invExternal.rowId,
-         invExternal.invoiceNumber,
-         invExternal.invoiceRunId,
-         invExternal.billingPeriodStart,
-         invExternal.billingPeriodEnd,
-         invExternal.BillingRunDate,
-         invExternal.accountNumber,
-         invExternal.type,
-         invExternal.po_number,
-         invExternal.contact_name,
-         invExternal.address,
-         invExternal.invoiceAmount

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceExternalLastRun.sql
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceExternalLastRun.sql
@@ -1,0 +1,28 @@
+SELECT
+  invExternal.rowId,
+  invExternal.invoiceNumber,
+  invExternal.invoiceRunId,
+  invExternal.billingPeriodStart,
+  invExternal.billingPeriodEnd,
+  invExternal.BillingRunDate,
+  invExternal.accountNumber,
+  invExternal.type,
+  invExternal.po_number,
+  invExternal.contact_name,
+  invExternal.address,
+  invExternal.invoiceAmount
+FROM ehr_billing.invoiceExternal invExternal WHERE invExternal.invoiceRunId =(SELECT max(invoiceRunId) from ehr_billing.invoiceExternal)
+
+GROUP BY
+         invExternal.rowId,
+         invExternal.invoiceNumber,
+         invExternal.invoiceRunId,
+         invExternal.billingPeriodStart,
+         invExternal.billingPeriodEnd,
+         invExternal.BillingRunDate,
+         invExternal.accountNumber,
+         invExternal.type,
+         invExternal.po_number,
+         invExternal.contact_name,
+         invExternal.address,
+         invExternal.invoiceAmount

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun.query.xml
@@ -1,0 +1,33 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="invoiceInternalLastRun" tableDbType="NOT_IN_DB">
+                <javaCustomizer class = "org.labkey.wnprc_billing.WNPRC_InvoiceCustomizer"/>
+                <tableTitle>Internal Invoices for the Last Billing Run</tableTitle>
+                <buttonBarOptions position="top" includeStandardButtons="true">
+                        <item text="Download Invoices" insertPosition="end" requiresSelection="true">
+                            <target method="POST">wnprc_billing/DownloadInvoices.view?</target>
+                        </item>
+                </buttonBarOptions>
+                <columns>
+                    <column columnName="rowId"/>
+                    <column columnName="invoiceNumber">
+                        <isKeyField>true</isKeyField> <!--pk needs to be set on a grid for the requiresSelection to work in above buttonBarOptions item -->
+                    </column>
+                    <column columnName="invoiceRunId"/>
+                    <column columnName="accountNumber">
+                        <fk>
+                            <fkDbSchema>ehr_billing</fkDbSchema>
+                            <fkTable>aliases</fkTable>
+                            <fkColumnName>alias</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="invoiceSentOn"/>
+                    <column columnName="invoiceAmount">
+                        <formatString>$###,##0.00</formatString>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun.sql
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun.sql
@@ -1,0 +1,28 @@
+SELECT
+       invInternal.rowId,
+       invInternal.invoiceNumber,
+       invInternal.invoiceRunId,
+       invInternal.billingPeriodStart,
+       invInternal.billingPeriodEnd,
+       invInternal.BillingRunDate,
+       invInternal.accountNumber,
+       invInternal.type,
+       invInternal.po_number,
+       invInternal.contact_name,
+       invInternal.address,
+       invInternal.invoiceAmount
+FROM ehr_billing.invoiceInternal invInternal WHERE invInternal.invoiceRunId =(SELECT max(invoiceRunId) from ehr_billing.invoiceInternal)
+GROUP BY
+         invInternal.rowId,
+         invInternal.invoiceNumber,
+         invInternal.invoiceRunId,
+         invInternal.billingPeriodStart,
+         invInternal.billingPeriodEnd,
+         invInternal.BillingRunDate,
+         invInternal.accountNumber,
+         invInternal.type,
+         invInternal.po_number,
+         invInternal.contact_name,
+         invInternal.address,
+         invInternal.invoiceAmount
+

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun.sql
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun.sql
@@ -1,4 +1,4 @@
-SELECT
+SELECT DISTINCT
        invInternal.rowId,
        invInternal.invoiceNumber,
        invInternal.invoiceRunId,
@@ -12,17 +12,3 @@ SELECT
        invInternal.address,
        invInternal.invoiceAmount
 FROM ehr_billing.invoiceInternal invInternal WHERE invInternal.invoiceRunId =(SELECT max(invoiceRunId) from ehr_billing.invoiceInternal)
-GROUP BY
-         invInternal.rowId,
-         invInternal.invoiceNumber,
-         invInternal.invoiceRunId,
-         invInternal.billingPeriodStart,
-         invInternal.billingPeriodEnd,
-         invInternal.BillingRunDate,
-         invInternal.accountNumber,
-         invInternal.type,
-         invInternal.po_number,
-         invInternal.contact_name,
-         invInternal.address,
-         invInternal.invoiceAmount
-

--- a/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun/.qview.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/invoiceInternalLastRun/.qview.xml
@@ -1,0 +1,31 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+    <columns>
+        <column name="invoiceNumber"/>
+        <column name="invoiceRunId"/>
+        <column name="invoiceRunId/billingPeriodStart"/>
+        <column name="invoiceRunId/billingPeriodEnd"/>
+        <column name="BillingRunDate"/>
+        <column name="accountNumber"/>
+        <column name="accountNumber/type"/>
+        <column name="accountNumber/po_number"/>
+        <column name="accountNumber/contact_name"/>
+        <column name="accountNumber/address"/>
+        <column name="invoiceAmount"/>
+        <column name="viewPdf">
+            <properties>
+                <property name="columnTitle" value="View PDF"/>
+            </properties>
+        </column>
+        <column name="downloadPDF">
+            <properties>
+                <property name="columnTitle" value="Download PDF"/>
+            </properties>
+        </column>
+        <column name="summarizedPDF">
+            <properties>
+                <property name="columnTitle" value="Summarized PDF"/>
+            </properties>
+        </column>
+    </columns>
+    <filters></filters>
+</customView>

--- a/wnprc_billing/resources/queries/ehr_billing/invoicedItems.query.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/invoicedItems.query.xml
@@ -48,6 +48,9 @@
                             <fkColumnName>project</fkColumnName>
                         </fk>
                     </column>
+                    <column columnName="invoiceId">
+                        <columnTitle>Invoice Run Id</columnTitle>
+                    </column>
                 </columns>
             </table>
         </tables>

--- a/wnprc_billing/resources/queries/ehr_billing/invoicedItems/.qview.xml
+++ b/wnprc_billing/resources/queries/ehr_billing/invoicedItems/.qview.xml
@@ -1,5 +1,6 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
     <columns>
+        <column name="invoiceId"/>
         <column name="Id"/>
         <column name="date"/>
         <column name="project"/>

--- a/wnprc_billing/resources/queries/ehr_billing/miscCharges.js
+++ b/wnprc_billing/resources/queries/ehr_billing/miscCharges.js
@@ -1,5 +1,8 @@
 require("ehr/triggers").initScript(this);
 
+var LABKEY = require("labkey");
+var billingHelper = new org.labkey.ehr_billing.query.EHRBillingTriggerHelper(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
+
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'ehr_billing', 'miscCharges', function(helper, scriptErrors, row, oldRow){
 
     if (!helper.isETL() && row) {

--- a/wnprc_billing/resources/queries/wnprc_billing/perDiemFeeRates.sql
+++ b/wnprc_billing/resources/queries/wnprc_billing/perDiemFeeRates.sql
@@ -31,7 +31,7 @@
     ci1.name AS item,
     ci1.chargeCategoryId.name AS category,
     pdt.comment,
-    ci1.serviceCode AS serviceCenter,
+    ci1.departmentCode AS serviceCenter,
     pdt.tierRate AS tierRate,
     NULL AS isMiscCharge,
 

--- a/wnprc_billing/resources/queries/wnprc_billing/perDiemRatesIntermediate.sql
+++ b/wnprc_billing/resources/queries/wnprc_billing/perDiemRatesIntermediate.sql
@@ -16,7 +16,7 @@
 SELECT perdiemsByDayOuter.Id,
        perdiemsByDayOuter.adate,
        perdiemsByDayOuter.edate,
-       sum(effectiveDays)           AS totalDaysPerAccount,
+       round(sum(effectiveDays), 5)          AS totalDaysPerAccount,
        perdiemsByDayOuter.account,
        perdiemsByDayOuter.project,
        perdiemsByDayOuter.locations AS comment
@@ -28,7 +28,7 @@ FROM (SELECT perdiemsByDay.singleDayDate,
              perdiemsByDay.edate,
              perdiemsByDay.locations,
              x.accountDays,
-             ROUND(CAST(1 AS DOUBLE) / x.accountDays, 2) AS effectiveDays
+             ROUND(CAST(1 AS DOUBLE) / x.accountDays, 5) AS effectiveDays
       FROM perdiemsByDay perdiemsByDay
       LEFT JOIN (SELECT
                        perdiemsByDay2.singleDayDate,

--- a/wnprc_billing/resources/queries/wnprc_billing/procedureFeeRates.sql
+++ b/wnprc_billing/resources/queries/wnprc_billing/procedureFeeRates.sql
@@ -32,7 +32,7 @@ FROM
   cr1.chargeId AS chargeId,
   ci1.name AS item,
   ci1.chargeCategoryId.name AS category,
-  ci1.serviceCode AS serviceCenter,
+  ci1.departmentCode AS serviceCenter,
   NULL AS isMiscCharge,
   pFees1.tierRate,
 
@@ -77,7 +77,7 @@ SELECT
   cr2.chargeId AS chargeId,
   ci2.name AS item,
   ci2.chargeCategoryId.name AS category,
-  ci2.serviceCode AS serviceCenter,
+  ci2.departmentCode AS serviceCenter,
   NULL AS isMiscCharge,
   pFees2.tierRate,
 

--- a/wnprc_billing/resources/views/financeManagement.html
+++ b/wnprc_billing/resources/views/financeManagement.html
@@ -33,50 +33,57 @@
                         {name: 'Invoices', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'invoice', 'query.viewName': 'AccountsReceivable', showImport: false})}
                     ]
                 },{
-                    header: 'Historic Billing Data',
-                    items: [
-                        {name: 'Invoice Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRuns'})},
-                        {name: 'Monthly Summary Direct', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRunMonthlySummaryDirect'})},
-                        {name: 'Monthly Summary Indirect', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRunMonthlySummaryIndirect'})},
-                        {name: 'All Invoiced Items', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoicedItems'})},
-                        {name: 'Access To Billing Data', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'dataAccess'})}
-                    ]
-                },{
                     header: 'Current Billing Period / Adjustments',
                     items: [
                         {name: 'Billing Period Summary / Discrepancy Report', url: LABKEY.ActionURL.buildURL('ldk', 'runNotification', ctx.EHRStudyContainer, {key: 'org.labkey.ehr_billing.notification.BillingNotification'})},
                         {name: 'Estimated Charges By Project', url: LABKEY.ActionURL.buildURL('wnprc_billing', 'invoiceEstimate', null)},
                         {name: 'View Charges and Adjustments Not Yet Billed', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', ctx.EHRStudyContainer, {schemaName: 'wnprc_billing', 'query.queryName': 'miscChargesNotBilledUpdate'})},
                         {name: 'Perform Billing Run', url: LABKEY.ActionURL.buildURL('ehr_billing', 'billingPipeline', null)},
+                        {name: 'Invoice External - Latest Run', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceExternalLastRun'})},
+                        {name: 'Invoice Internal - Latest Run', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceInternalLastRun'})}
+
+                        ].concat(issuesContainer ? [{name: 'Finance Issue Tracker', url: LABKEY.ActionURL.buildURL('issues', 'begin', issuesContainer)}] : [])
+                },{
+                    header: 'Charges Data Entry',
+                    items: [
                         {name: 'Enter Charges with Animal Ids', url: LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', ctx.EHRStudyContainer, {formType: 'Charges'})},
-                        {name: 'Enter Charges without Animal Ids', url: LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', ctx.EHRStudyContainer, {formType: 'NonAnimalCharges'})},
-                        {name: 'Invoice External', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceExternal'})},
-                        {name: 'Invoice Internal', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceInternal'})}
-                    ].concat(issuesContainer ? [{name: 'Finance Issue Tracker', url: LABKEY.ActionURL.buildURL('issues', 'begin', issuesContainer)}] : [])
+                        {name: 'Enter Charges without Animal Ids', url: LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', ctx.EHRStudyContainer, {formType: 'NonAnimalCharges'})}
+                    ]
+                },{
+                    header: 'Historic Billing Data',
+                    items: [
+                        {name: 'Invoice Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRuns'})},
+                        {name: 'Monthly Summary Direct', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRunMonthlySummaryDirect'})},
+                        {name: 'Monthly Summary Indirect', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRunMonthlySummaryIndirect'})},
+                        {name: 'All Invoiced Items', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoicedItems'})},
+                        {name: 'Invoice External - All Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceExternal'})},
+                        {name: 'Invoice Internal - All Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceInternal'})}
+                    ]
                 },{
                     header: 'Reference Tables',
                     items: [
                         {name: 'IACUC Protocols', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', ctx.EHRStudyContainer, {schemaName: 'ehr', 'query.queryName': 'protocol'})},
                         {name: 'WNPRC Projects', url: LABKEY.ActionURL.buildURL(queryController, queryAction, ctx.EHRStudyContainer, {schemaName: 'ehr', 'query.queryName': 'project', showImport: true})},
-                        {name: 'Grant Accounts', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'aliases', showImport: true})},
+                        {name: 'Grant Accounts - Active', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'aliases', 'query.viewName': 'Active Grant Accounts', showImport: false})},
+                        {name: 'Grant Accounts - ALL', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'aliases', showImport: true})},
                         {name: 'Investigators', url: LABKEY.ActionURL.buildURL(queryController, queryAction, ctx.EHRStudyContainer, {schemaName: 'ehr', 'query.queryName': 'investigators', showImport: true})},
                         {name: 'Financial Analysts', url: LABKEY.ActionURL.buildURL(queryController, queryAction, ctx.EHRStudyContainer, {schemaName: 'ehr_billing', 'query.queryName': 'fiscalAuthorities', showImport: true})},
                         {name: 'Departments', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'wnprc_billing', 'query.queryName': 'groups',showImport: true})}
                     ]
                 },{
-                    header: 'Rates and Fee Structure',
+                    header: 'Charge Category and Rates',
                     items: [
-//                        {name: 'Explanation of Rates', url: LABKEY.ActionURL.buildURL('wnprc_billing', 'rateCalculation')},
+                        {name: 'Charge Units', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'chargeUnits', showImport: true})},
+                        {name: 'Chargeable Item Categories', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'chargeableItemCategories', showImport: true})},
                         {name: 'Chargeable Items', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'chargeableItems', showImport: true})},
                         {name: 'Standard Rates', url: LABKEY.ActionURL.buildURL("query", "executeQuery", null, {schemaName: 'ehr_billing', 'query.queryName': 'chargeRates', showImport: true})},
-                        {name: 'Charge Units', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'chargeUnits', showImport: true})},
                         {name: 'Tier Rates', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'wnprc_billing', 'query.queryName': 'tierRates', showImport: true})},
                     ]
                 },{
                     header: 'Other',
                     items: [
-                        {name: 'Import Historical Misc. Charges', url: LABKEY.ActionURL.buildURL(queryController, queryAction, ctx.EHRStudyContainer, {schemaName: 'ehr_billing', 'query.queryName': 'miscCharges', showImport: true})},
-                        {name: 'Chargeable Item Categories', url: LABKEY.ActionURL.buildURL(queryController, queryAction, null, {schemaName: 'ehr_billing', 'query.queryName': 'chargeableItemCategories', showImport: true})}
+                        {name: 'Access To Billing Data', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'dataAccess'})},
+                        {name: 'Import Historical Misc. Charges', url: LABKEY.ActionURL.buildURL(queryController, queryAction, ctx.EHRStudyContainer, {schemaName: 'ehr_billing', 'query.queryName': 'miscCharges', showImport: true})}
                     ]
                 }]
             }]

--- a/wnprc_billing/resources/views/financeManagement.html
+++ b/wnprc_billing/resources/views/financeManagement.html
@@ -39,6 +39,7 @@
                         {name: 'Estimated Charges By Project', url: LABKEY.ActionURL.buildURL('wnprc_billing', 'invoiceEstimate', null)},
                         {name: 'View Charges and Adjustments Not Yet Billed', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', ctx.EHRStudyContainer, {schemaName: 'wnprc_billing', 'query.queryName': 'miscChargesNotBilledUpdate'})},
                         {name: 'Perform Billing Run', url: LABKEY.ActionURL.buildURL('ehr_billing', 'billingPipeline', null)},
+                        {name: 'Invoice Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRuns'})},
                         {name: 'Invoice External - Latest Run', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceExternalLastRun'})},
                         {name: 'Invoice Internal - Latest Run', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceInternalLastRun'})}
 
@@ -52,12 +53,11 @@
                 },{
                     header: 'Historic Billing Data',
                     items: [
-                        {name: 'Invoice Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRuns'})},
                         {name: 'Monthly Summary Direct', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRunMonthlySummaryDirect'})},
                         {name: 'Monthly Summary Indirect', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceRunMonthlySummaryIndirect'})},
-                        {name: 'All Invoiced Items', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoicedItems'})},
-                        {name: 'Invoice External - All Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceExternal'})},
-                        {name: 'Invoice Internal - All Runs', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceInternal'})}
+                        {name: 'Invoiced Items', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoicedItems'})},
+                        {name: 'Invoice External', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceExternal'})},
+                        {name: 'Invoice Internal', url: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'ehr_billing', 'query.queryName': 'invoiceInternal'})}
                     ]
                 },{
                     header: 'Reference Tables',

--- a/wnprc_billing/resources/web/wnprc_billing/model/sources/NonAnimalCharges.js
+++ b/wnprc_billing/resources/web/wnprc_billing/model/sources/NonAnimalCharges.js
@@ -20,7 +20,7 @@ EHR.model.DataModelManager.registerMetadata('NonAnimalCharges', {
                 lookup: {
                     schemaName: 'ehr_billing',
                     queryName: 'aliases',
-                    filterArray: [LABKEY.Filter.create('isAcceptingCharges', 'Y', LABKEY.Filter.Types.EQUAL)]
+                    filterArray: [LABKEY.Filter.create('isAcceptingCharges', 'N', LABKEY.Filter.Types.NEQ_OR_NULL)]
                 },
                 columnConfig: {
                     width: 125

--- a/wnprc_billing/resources/web/wnprc_billing/model/sources/NonAnimalCharges.js
+++ b/wnprc_billing/resources/web/wnprc_billing/model/sources/NonAnimalCharges.js
@@ -17,6 +17,11 @@ EHR.model.DataModelManager.registerMetadata('NonAnimalCharges', {
             debitedaccount: {
                 hidden: false,
                 xtype: 'wnprc_billing-miscchargesdebitacctentryfield',
+                lookup: {
+                    schemaName: 'ehr_billing',
+                    queryName: 'aliases',
+                    filterArray: [LABKEY.Filter.create('isAcceptingCharges', 'Y', LABKEY.Filter.Types.EQUAL)]
+                },
                 columnConfig: {
                     width: 125
                 }

--- a/wnprc_billing/src/org/labkey/wnprc_billing/dataentry/ChargesFormSection.java
+++ b/wnprc_billing/src/org/labkey/wnprc_billing/dataentry/ChargesFormSection.java
@@ -5,6 +5,7 @@ import org.labkey.api.ehr.dataentry.SimpleFormSection;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Class to administer Ext4JS component/panel for ehr_billing.miscCharges table for data entry form.
@@ -19,8 +20,30 @@ public class ChargesFormSection extends SimpleFormSection
     public ChargesFormSection(EHRService.FORM_SECTION_LOCATION location)
     {
         super("ehr_billing", "miscCharges", "Misc. Charges", "ehr-gridpanel", location);
-        setConfigSources(Collections.singletonList("Task"));
-        addClientDependency(ClientDependency.fromPath("wnprc_billing/model/sources/MiscCharges.js"));
         _allowRowEditing = false;
+
+        addClientDependency(ClientDependency.fromPath("wnprc_billing/model/sources/MiscCharges.js"));
+
+        setConfigSources(Collections.singletonList("Task"));
+    }
+
+    @Override
+    public List<String> getTbarButtons()
+    {
+        List<String> defaultButtons = super.getTbarButtons();
+
+        // Remove the default buttons that don't make sense for charges with animal ids
+        defaultButtons.remove("COPYFROMSECTION");
+        defaultButtons.remove("TEMPLATE");
+
+        return defaultButtons;
+    }
+
+    @Override
+    public List<String> getTbarMoreActionButtons()
+    {
+        List<String> defaultMoreActionButtons = super.getTbarMoreActionButtons();
+        defaultMoreActionButtons.remove("BULKEDIT");
+        return defaultMoreActionButtons;
     }
 }

--- a/wnprc_billing/src/org/labkey/wnprc_billing/dataentry/NonAnimalChargesFormSection.java
+++ b/wnprc_billing/src/org/labkey/wnprc_billing/dataentry/NonAnimalChargesFormSection.java
@@ -5,6 +5,7 @@ import org.labkey.api.ehr.dataentry.SimpleFormSection;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Class to administer Ext4JS component/panel for ehr_billing.miscCharges data entry for charges without animal id and project
@@ -19,8 +20,33 @@ public class NonAnimalChargesFormSection extends SimpleFormSection {
     public NonAnimalChargesFormSection(EHRService.FORM_SECTION_LOCATION location)
     {
         super("ehr_billing", "miscCharges", "Misc. Charges", "ehr-gridpanel", location);
-        setConfigSources(Collections.singletonList("Task"));
-        addClientDependency(ClientDependency.fromPath("wnprc_billing/model/sources/NonAnimalCharges.js"));
         _allowRowEditing = false;
+
+        addClientDependency(ClientDependency.fromPath("wnprc_billing/model/sources/NonAnimalCharges.js"));
+
+        setConfigSources(Collections.singletonList("Task"));
+    }
+
+    @Override
+    public List<String> getTbarButtons()
+    {
+        List<String> defaultButtons = super.getTbarButtons();
+
+        // Remove the default buttons that don't make sense for charges Without animal ids
+        defaultButtons.remove("ADDANIMALS");
+        defaultButtons.remove("COPYFROMSECTION");
+        defaultButtons.remove("TEMPLATE");
+
+        return defaultButtons;
+    }
+
+    @Override
+    public List<String> getTbarMoreActionButtons()
+    {
+        List<String> defaultMoreActionButtons = super.getTbarMoreActionButtons();
+        defaultMoreActionButtons.remove("BULKEDIT");
+        defaultMoreActionButtons.remove("GUESSPROJECT");
+        defaultMoreActionButtons.remove("COPY_IDS");
+        return defaultMoreActionButtons;
     }
 }


### PR DESCRIPTION
- Increase scale when rounding perdiem days. Make certain fields required for aliases.
- Hide non-relevant buttons from data entry.
- Filter debit account on non-animal charges data entry based on 'isAcceptingCharges' field.
- Added queries and views for invoice internal and external for the latest run.
- Added a view for Active accounts.
- Reshuffle/rename and group links into appropriate categories.
- Use departmentCode instead of serviceCode in pdf generation. Make departmentCode required.
- Set isAcceptingCharges true by default on upload, and change filtering on data entry form drop down to be either NULL (to account for null values on client's test server) or not equal to false.
- Automated test updates/fixes based on the above updates.