### PR TITLE
Make restraints no longer a required field for research ultrasounds

### DIFF
--- a/WNPRC_EHR/resources/queries/study/research_ultrasounds.js
+++ b/WNPRC_EHR/resources/queries/study/research_ultrasounds.js
@@ -74,11 +74,7 @@ function onInsert(helper, scriptErrors, row, oldRow) {
 
         let validationFailed = false;
 
-        if (!row.restraintType) {
-            validationFailed = true;
-            EHR.Server.Utils.addError(scriptErrors, "restraintType", "Restraint Type is a required field", "ERROR");
-        }
-        else {
+        if (!!row.restraintType) {
             LABKEY.Query.selectRows({
                 schemaName: 'ehr_lookups',
                 queryName: 'restraint_type',
@@ -415,5 +411,5 @@ function getValidMeasurements() {
 }
 
 function getTruthiness(value) {
-    return (value === true || value == 1 || (!!value && (typeof value === 'string' || value instanceof String) && (value.toUpperCase() === "TRUE" || value.toUpperCase() === "YES")));
+    return (value === true || value == 1 || (!!value && (typeof value === 'string' || value instanceof String) && (value.toUpperCase().trim() === "TRUE" || value.toUpperCase().trim() === "YES")));
 }

--- a/WNPRC_EHR/resources/queries/study/restraints.js
+++ b/WNPRC_EHR/resources/queries/study/restraints.js
@@ -22,7 +22,9 @@ function setDescription(row, helper){
     let description = [];
 
     description.push("Restraint Type: " + row.restraintType);
-    description.push("Remarks: " + row.remarks);
+    if (row.remarks) {
+        description.push("Remarks: " + row.remarks);
+    }
 
     return description;
 }

--- a/WNPRC_EHR/resources/web/wnprc_ehr/animalPortal.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/animalPortal.js
@@ -31,9 +31,19 @@ EHR.reports.AnimalPortal =  function(panel2,tab) {
             //animalFolder.listFiles({success:function(){console.log("success",arguments)},failure:function(){console.log("failed",arguments)},forceReload:true,path:"/@files/animalPortal/"});
             console.log("Id of animal  " + animalIds);
 
+            tab.add({
+                xtype: 'label',
+                html: 'Ultrasounds for breeding or diagnosis issues label with the date (YYYY-MM-DD) and ultrasound purpose (example: ultrasounds -> pregnancies -> 2020 -> 2020-11-10).<br/>' +
+                        'Organize experimental ultrasounds under the pregnancies folder.<br/>' +
+                        '<strong>Instructions for research ultrasounds:</strong><br/>' +
+                        'Label each of the animal pregnancies by the year the pregnancy occurred (example: ultrasounds -> pregnancies -> 2020).<br/>' +
+                        'For pregnancies with overlapping or multiple pregnancies make sure to include both years (example: ultrasounds -> pregnancies -> 2020-2021).<br/>' +
+                        'Within the folder for the animal pregnancy (example: 2020) include the ultrasounds organized by folders labeled with the year, month, ' +
+                        'the day ultrasound images are acquired <br/>' +
+                        '(example: ultrasounds -> pregnancies -> 2020 -> 2020-11-10).'
+            });
 
-            var panel = tab.add({id: 'filesDiv', style: 'margin-bottom:20px'});
-            //toAdd.push({id: 'filesDiv', style: 'margin-bottom:20px'});
+            var panel = tab.add({id: 'filesDiv', style: 'margin-bottom:20px'})
 
             var handler = function (location)
             {
@@ -101,6 +111,7 @@ EHR.reports.AnimalPortal =  function(panel2,tab) {
                                                         const folders = [
                                                             "Ultrasounds",
                                                             "Radiology Reports",
+                                                            "Medical Record",
                                                             "Misc Docs",
                                                             "Images",
                                                             "Lab Reports",
@@ -119,33 +130,59 @@ EHR.reports.AnimalPortal =  function(panel2,tab) {
                                                                     console.log("folder created for " + animalIds);
 
                                                                     var createYears = 0;
+                                                                    if (folder === "Medical Record"){
+                                                                        AddComment("/@files/" + animalIds + "/" + folder ,"Add vendor's medical record inside this folder")
+                                                                    }
                                                                     if (folder === "Ultrasounds"){
-                                                                        let year = new Date().getFullYear();
+                                                                        AddComment("/@files/" + animalIds + "/" + folder ,"Add pregnancies ultrasounds inside the pregnancies folder");
+                                                                        var createPregnancyFolder = 0;
                                                                         animalFolder.createDirectory({
-                                                                            path: "/@files/" + animalIds + "/" + folder + "/" + year,
-                                                                            comment: "Create a folder per ultrasound date inside year's folder",
-                                                                            success: function (){
-                                                                                console.log("created " + folder + " folder for " + animalIds);
-                                                                                createYears++;
-                                                                                if (createYears === folders.length) {
+                                                                            path:"/@files/" + animalIds + "/" + folder + "/Pregnancies",
+                                                                            success: function(){
+                                                                                console.log("created pregnancies folder for " + animalIds);
+                                                                                createPregnancyFolder++;
+                                                                                if (createPregnancyFolder === 1){
                                                                                     handler(location.id);
                                                                                 }
-                                                                                console.log("folder created for " + animalIds);
+                                                                                console.log ("folder created for pregnancies for animal " + animalIds);
 
-                                                                                var createDateFolder = 0;
-                                                                                let today = new Date();
-                                                                                let monthNumber = today.getMonth() + 1;
-                                                                                let dateString = today.getFullYear() + "-" + monthNumber + "-" + today.getDate();
+                                                                                //Create a folder for the year
+                                                                                let year = new Date().getFullYear();
                                                                                 animalFolder.createDirectory({
-                                                                                    path: "/@files/" + animalIds + "/" + folder + "/" + year + "/" + dateString,
-                                                                                    comment: "Create a folder per ultrasound date inside year's folder",
-                                                                                    success: function (){
-                                                                                        console.log("created " + dateString + " folder for " + animalIds);
-                                                                                        createDateFolder++;
-                                                                                        if (createDateFolder === folders.length) {
+                                                                                    path: "/@files/" + animalIds + "/" + folder + "/Pregnancies/" + year,
+                                                                                    success: function (data){
+                                                                                        console.log("created " + folder + " folder for " + animalIds);
+                                                                                        console.log("value of data "+ data);
+                                                                                        createYears++;
+                                                                                        if (createYears === 1) {
                                                                                             handler(location.id);
+                                                                                            AddComment("/@files/" + animalIds + "/" + folder + "/Pregnancies/" + year,"Add images to the corresponding date folder within the year folder");
                                                                                         }
                                                                                         console.log("folder created for " + animalIds);
+
+                                                                                        //Creating a folder for the current date
+                                                                                        let createDateFolder = 0;
+                                                                                        let today = new Date();
+                                                                                        let monthNumber = today.getMonth() + 1;
+                                                                                        let dateString = today.getFullYear() + "-" + monthNumber + "-" + today.getDate();
+                                                                                        animalFolder.createDirectory({
+                                                                                            path: "/@files/" + animalIds + "/" + folder + "/Pregnancies/" + year + "/" + dateString,
+                                                                                            comment: "Create a folder per ultrasound date inside year's folder",
+                                                                                            success: function (){
+                                                                                                console.log("created " + dateString + " folder for " + animalIds);
+                                                                                                createDateFolder++;
+                                                                                                if (createDateFolder === 1) {
+                                                                                                    handler(location.id);
+                                                                                                    AddComment("/@files/" + animalIds + "/" + folder + "/Pregnancies/" + year + "/" + dateString,'Add ultrasound images to the corresponding date folder');
+                                                                                                }
+                                                                                                console.log("folder created for " + animalIds);
+
+                                                                                            },
+                                                                                            failure: function (error) {
+                                                                                                console.log("failed to created" + folder + " folder" + error.status)
+                                                                                            }
+                                                                                        })
+
 
                                                                                     },
                                                                                     failure: function (error) {
@@ -153,12 +190,9 @@ EHR.reports.AnimalPortal =  function(panel2,tab) {
                                                                                     }
                                                                                 })
 
-
-                                                                            },
-                                                                            failure: function (error) {
-                                                                                console.log("failed to created" + folder + " folder" + error.status)
                                                                             }
                                                                         })
+
                                                                     }
                                                                 },
                                                                 failure: function (error) {
@@ -237,5 +271,69 @@ EHR.reports.AnimalPortal =  function(panel2,tab) {
 
 
 };
+
+AddComment = function(location, comment){
+    let savedLocation = location.replace(" ","%20");
+    LABKEY.Query.selectRows({
+        schemaName: 'exp',
+        queryName: 'Data',
+        containerPath: 'WNPRC/EHR/AnimalPortal',
+        columns:'rowid,lsid,DataFileUrl,name',
+        filterArray:[
+            LABKEY.Filter.create('DataFileUrl', savedLocation, LABKEY.Filter.Types.CONTAINS)
+        ],
+        success: function (data){
+            let toUpdate = [];
+
+            if (!data.rows || !data.rows.length){
+                return;
+            }
+            Ext4.Array.forEach(data.rows, function (row){
+                let filePath = row.DataFileUrl;
+                if (filePath.endsWith(savedLocation)){
+                    let obj = {};
+                    obj.LSID = row.LSID;
+                    obj.rowid = row.RowId;
+                    obj['Flag/Comment']= comment;
+                    console.log(obj);
+
+                    toUpdate.push(obj);
+
+                }
+
+
+            });
+
+            if (toUpdate.length){
+                LABKEY.Query.updateRows({
+                    schemaName: 'exp',
+                    queryName: 'Data',
+                    containerPath: 'WNPRC/EHR/AnimalPortal',
+                    rows: toUpdate,
+                    success: function(data){
+                        console.log("Add comment to the folder");
+                    },
+                    failure: function (error)
+                    {
+                        console.log("failed to created folder" + error.status)
+                    }
+
+
+                });
+            }
+
+            /*data = data || {};
+            data.rows = data.rows || [];*/
+        }
+
+
+    })
+    let folderComment= {
+        "flag/Comment": comment
+    }
+
+
+
+}
 
 

--- a/WNPRC_EHR/resources/web/wnprc_ehr/ext4/data/SingleAnimal/ResearchUltrasoundsServerStore.js
+++ b/WNPRC_EHR/resources/web/wnprc_ehr/ext4/data/SingleAnimal/ResearchUltrasoundsServerStore.js
@@ -5,4 +5,32 @@ Ext4.define('WNPRC.ext.data.ResearchUltrasoundsServerStore', {
     constructor: function(){
         this.callParent(arguments);
     },
+
+    getCommands: function(records, forceUpdate, validateOnly) {
+        let commands = this.callParent(arguments);
+
+        //check if the restraints section has been filled out. if not, remove it so that it doesn't save a blank record
+        //currently there is only a single animal form, so the looping below
+        //is not really necessary, but could be in the future if a multi-animal
+        //form is created for entering research ultrasounds
+        if (commands.commands.length > 0 && commands.commands[0].queryName === "restraints") {
+            //loop through in reverse order for both loops so that splicing out elements in the
+            //array doesn't mess up the array indexing
+            for (let i = commands.records.length - 1; i >= 0; i--) {
+                for (let j = commands.records[i].length - 1; j >= 0; j--) {
+                    if (!commands.records[i][j].data.restraintType) {
+                        commands.records[i].splice(j, 1);
+                    }
+                }
+                //if all records in the current array were removed, then also remove
+                //the array itself, as well as the corresponding command
+                if (commands.records[i].length === 0) {
+                    commands.commands.splice(i, 1);
+                    commands.records.splice(i, 1);
+                }
+            }
+        }
+
+        return commands;
+    }
 });


### PR DESCRIPTION
- Restraints is no longer a required field
- If no restraint is entered the server store will remove the record entirely so that a blank record is not saved
- Updated restraints description generation so that undefined fields are not added to the description