### PR TITLE
21.3w fb water test merge

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.000-21.001.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.000-21.001.sql
@@ -1,8 +1,8 @@
 DROP TABLE IF EXISTS ehr_lookups.husbandry_frequency;
-DROP TABLE IF EXISTS wnprc.husbandry_frequency;
+
 CREATE TABLE wnprc.husbandry_frequency
 (
-    rowid      serial                    NOT NULL,
+    RowId      serial                    NOT NULL,
     meaning    varchar(100) DEFAULT NULL NOT NULL,
     dayofweek  integer,
     sort_order integer,

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.001-21.002.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.001-21.002.sql
@@ -1,0 +1,27 @@
+DROP TABLE IF EXISTS wnprc.husbandry_frequency;
+CREATE TABLE wnprc.husbandry_frequency
+(
+    rowid      serial                    NOT NULL,
+    meaning    varchar(100) DEFAULT NULL NOT NULL,
+    dayofweek  integer,
+    sort_order integer,
+    active     bool         DEFAULT true,
+    altmeaning varchar(30),
+    CONSTRAINT PK_husbandry_frequency PRIMARY KEY (rowid)
+)
+    WITH (OIDS= FALSE);
+
+INSERT INTO wnprc.husbandry_frequency
+(rowid, meaning,dayofweek, sort_order,active,altmeaning)
+VALUES
+(1, 'Daily - AM',       NULL,   1,'TRUE', 'AM'),
+(2, 'Daily - PM',       NULL,   2,'TRUE','PM'),
+(3, 'Daily - AM/PM',    NULL,   3,'TRUE',''),
+(4, 'Daily - Any Time', NULL,   4,'TRUE','Any Time'),
+(5, 'Sunday',           '1',    5,'TRUE',''),
+(6, 'Monday',           '2',    6,'TRUE',''),
+(7, 'Tuesday',          '3',    7,'TRUE',''),
+(8, 'Wednesday',        '4',    8,'TRUE',''),
+(9, 'Thursday',         '5',    9,'TRUE',''),
+(10, 'Friday',          '6',    10,'TRUE',''),
+(11, 'Saturday',        '7',    11,'TRUE','');

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 21.001;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 21.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Reverting changes and increasing schema version to modify the schema for wnprc

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Revert changes to wnprc-21.000-21.001 and adding a new sql to drop and create the new lookup table.
