### PR TITLE
21.11 fb purchasing line item numbers

### DIFF
--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems.query.xml
@@ -14,6 +14,9 @@
                             <fkTable>purchasingRequests</fkTable>
                         </fk>
                     </column>
+                    <column columnName="lineItemNumber">
+                        <required>true</required>
+                    </column>
                     <column columnName="item">
                         <required>true</required>
                     </column>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems.query.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems.query.xml
@@ -13,6 +13,7 @@
                             <fkDbSchema>ehr_purchasing</fkDbSchema>
                             <fkTable>purchasingRequests</fkTable>
                         </fk>
+                        <url>/wnprc_purchasing/purchasingRequest.view?requestRowId=${requestRowId}</url>
                     </column>
                     <column columnName="lineItemNumber">
                         <required>true</required>

--- a/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems/.qview.xml
+++ b/WNPRC_Purchasing/resources/queries/ehr_purchasing/lineItems/.qview.xml
@@ -6,6 +6,7 @@
                 <property name="columnTitle" value="Request Status"/>
             </properties>
         </column>
+        <column name="lineItemNumber"/>
         <column name="item"/>
         <column name="itemUnitId"/>
         <column name="controlledSubstance"/>
@@ -23,4 +24,7 @@
             </properties>
         </column>
     </columns>
+    <sorts>
+        <sort column="requestRowId, lineItemNumber"/>
+    </sorts>
 </customView>

--- a/WNPRC_Purchasing/resources/views/purchasingLanding.html
+++ b/WNPRC_Purchasing/resources/views/purchasingLanding.html
@@ -1,5 +1,6 @@
 <div id="<%=h('wnprc_purchasing-admin-page')%>"></div>
 <h4 style="font-family: Roboto;font-size: 14px;font-weight: bold;">WNPRC Purchasing Portal</h4>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-requester.view?">Purchasing Requests</a></span></div>
+<div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%>/query/WNPRC/WNPRC_Units/Operation_Services/WNPRC%20Purchasing/executeQuery.view?schemaName=ehr_purchasing&query.queryName=lineItems">My Purchased Items</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-purchaseAdmin.view?">Purchasing Admin</a></span></div>
 <div style="margin-left:10px;height: 25px;"><span><a class="labkey-text-link" href="<%=contextPath%><%=containerPath%>/WNPRC_Purchasing-purchaseReceiver.view?">Purchasing Receiver</a></span></div>

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.scss
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.scss
@@ -45,6 +45,10 @@
   width: 100%;
 }
 
+.line-item-number {
+  margin-left: -4%;
+}
+
 .description-input {
   margin-left: -3%;
 }

--- a/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
+++ b/WNPRC_Purchasing/src/client/RequestEntry/RequestEntry.tsx
@@ -149,8 +149,8 @@ export const App: FC = memo(() => {
                 const lineItemVals = await getData(
                     'ehr_purchasing',
                     'lineItems',
-                    'rowId, requestRowId, item, itemUnitId, controlledSubstance, quantity, quantityReceived, unitCost, itemStatusId',
-                    undefined,
+                    'rowId, requestRowId, lineItemNumber, item, itemUnitId, controlledSubstance, quantity, quantityReceived, unitCost, itemStatusId',
+                    'lineItemNumber',
                     requestRowIdFilter
                 );
 
@@ -160,6 +160,7 @@ export const App: FC = memo(() => {
                         return LineItemModel.create({
                             rowId: val.rowId,
                             requestRowId: reqRowId,
+                            lineItemNumber: val.lineItemNumber,
                             item: val.item,
                             controlledSubstance: val.controlledSubstance,
                             itemUnit: val.itemUnitId,
@@ -189,7 +190,7 @@ export const App: FC = memo(() => {
                 const qcStateVals = await getData('core', 'qcState', 'RowId, Label');
                 const idx = qcStateVals.findIndex(qcstate => qcstate['Label'] === 'Review Pending');
                 setRequestOrderModel(RequestOrderModel.create({qcState: qcStateVals[idx].RowId}));
-                setLineItems([LineItemModel.create({qcState: qcStateVals[idx].RowId})]);
+                setLineItems([LineItemModel.create({qcState: qcStateVals[idx].RowId, lineItemNumber: 1})]);
                 setIsLoading(false);
             }
         })();

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -58,12 +58,9 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
 
     let columnCount = 8;
     if (canViewPricingInfo) {
-        columnCount++;
+        columnCount += 2;
     }
     if (hasRequestId && !isReorder) {
-        columnCount++;
-    }
-    if (canViewPricingInfo) {
         columnCount++;
     }
     const deleteColWidth = 12 - columnCount;

--- a/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemRow.tsx
@@ -9,6 +9,7 @@ import { LineItemModel } from '../model';
 import {
     ControlledSubstance,
     DescriptionInput,
+    LineItemNumber,
     SubtotalInput,
     UnitInput,
     UnitCostInput,
@@ -55,10 +56,25 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
         onDelete(rowIndex);
     }, [onDelete, rowIndex]);
 
+    let columnCount = 8;
+    if (canViewPricingInfo) {
+        columnCount++;
+    }
+    if (hasRequestId && !isReorder) {
+        columnCount++;
+    }
+    if (canViewPricingInfo) {
+        columnCount++;
+    }
+    const deleteColWidth = 12 - columnCount;
+
     return (
         <>
             {
                 <Row className="line-item-row" key={'line-item-row-' + rowIndex}>
+                    <Col xs={1}>
+                        <LineItemNumber value={model.lineItemNumber} />
+                    </Col>
                     <Col xs={4}>
                         <DescriptionInput
                             value={model.item}
@@ -116,13 +132,8 @@ export const LineItemRow: FC<LineItemProps> = memo(props => {
                         </Col>
                     }
 
-                    <Col xs={2}/>
-                    <Col xs={1}/>
-                    { (!hasRequestId || isReorder) &&
-                        <Col xs={2}/>
-                    }
                     { canDelete &&
-                        <Col xs={1}>
+                        <Col xs={deleteColWidth}>
                                 <span
                                         id={'delete-line-item-row-' + rowIndex}
                                         title="Delete item"

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanel.tsx
@@ -47,8 +47,10 @@ export const LineItemsPanel: FC<Props> = memo(props => {
     );
 
     const onClickAddRow = useCallback(()=> {
+        const nextLineItemNumber = Math.max(...lineItems.map(model => model.lineItemNumber), 0) + 1;
+
         const updatedLineItems = produce(lineItems, (draft: Draft<LineItemModel[]>) => {
-            draft.push(LineItemModel.create());
+            draft.push(LineItemModel.create({lineItemNumber: nextLineItemNumber}));
         });
         onChange(updatedLineItems);
     }, [lineItems]);
@@ -62,6 +64,8 @@ export const LineItemsPanel: FC<Props> = memo(props => {
             }, 0)
         )
     }, [lineItems]);
+
+    const calcTotalCol = (hasRequestId && !isReorder) ? 10 : 9;
 
     return (
         <>
@@ -80,6 +84,7 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                 </div>
                 <div>
                         <Row className="line-item-row-header">
+                            <Col xs={1}>Line no.</Col>
                             <Col xs={4}>Part no./Item description *</Col>
                             <Col xs={1}>Controlled substance</Col>
                             <Col xs={1}>Unit *</Col>
@@ -118,15 +123,11 @@ export const LineItemsPanel: FC<Props> = memo(props => {
                             <>
                                 <div>
                                     <Row>
-                                        <Col xs={6}></Col>
-                                        {(hasRequestId && !isReorder) &&
-                                            <Col xs={1}></Col>
-                                        }
-                                        <Col xs={1}></Col>
-                                        <Col className="calc-total" xs={1}>
+                                        <Col className="calc-total" xs={calcTotalCol}>
                                             Total ($):
                                         </Col>
-                                        <Col className="calc-total-val" xs={1}>{getTotal}
+                                        <Col className="calc-total-val" xs={1}>
+                                            {getTotal}
                                         </Col>
                                     </Row>
                                 </div>

--- a/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/LineItemsPanelInputs.tsx
@@ -11,6 +11,21 @@ interface InputProps {
     isReadOnly?: boolean;
 }
 
+export const LineItemNumber: FC<InputProps> = memo(props => {
+    const { value } = props;
+
+    return (
+        <input
+            className={
+                'line-item-row-input line-item-number form-control'
+            }
+            value={value}
+            id="item-line-number"
+            disabled={true}
+        />
+    );
+});
+
 export const DescriptionInput: FC<InputProps> = memo(props => {
     const { onChange, value, hasError, isReadOnly } = props;
 

--- a/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
+++ b/WNPRC_Purchasing/src/client/components/RequestOrderPanelInputs.tsx
@@ -233,7 +233,7 @@ export const SpecialInstructionInput: FC<InputProps> = memo(props => {
 
     return (
         <div>
-            <PurchasingFormInput label="Special instructions">
+            <PurchasingFormInput label="Comments/Special instructions">
                 <textarea
                     className="special-instr-input form-control"
                     value={value}

--- a/WNPRC_Purchasing/src/client/model.ts
+++ b/WNPRC_Purchasing/src/client/model.ts
@@ -114,6 +114,7 @@ export class LineItemModel {
     readonly rowId?: number;
     readonly rowIndex?: number; // mainly to identify errors coming from the server
     readonly requestRowId?: number;
+    readonly lineItemNumber?: number = 0;
     readonly item: string;
     readonly controlledSubstance: boolean = false;
     readonly itemUnit: number; // rowId of ehr_purchasing.itemUnits

--- a/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
+++ b/WNPRC_Purchasing/src/org/labkey/wnprc_purchasing/WNPRC_PurchasingManager.java
@@ -256,6 +256,11 @@ public class WNPRC_PurchasingManager
                 row = new CaseInsensitiveHashMap<>();
                 row.put("requestRowId", insertedPurchasingReq.get(0).get("rowId"));
 
+                if (null == lineItem.get("lineItemNumber")) {
+                    lineItemErrors.addError(new PropertyValidationError("Required value for 'Line no.' not provided", "lineItemNumber"));
+                } else {
+                    row.put("lineItemNumber", lineItem.get("lineItemNumber"));
+                }
                 if (null == lineItem.get("item"))
                     lineItemErrors.addError(new PropertyValidationError("Required value for 'Part no./Item description' not provided", "item"));
                 else

--- a/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
+++ b/WNPRC_Purchasing/test/src/org/labkey/test/tests/wnprc_purchasing/WNPRC_PurchasingTest.java
@@ -450,7 +450,7 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
         checker().verifyEquals("Invalid value for Accounts to charge ", "acct100 - Assay Services", requestPage2.getAccountsToCharge());
         checker().verifyEquals("Invalid value for Vendor ", "Real Santa Claus", requestPage2.getVendor());
         checker().verifyEquals("Invalid value for BusinessPurpose ", "Holiday Party", requestPage2.getBusinessPurpose());
-        checker().verifyEquals("Invalid value for Special Instructions ", "Ho Ho Ho", requestPage2.getSpecialInstructions());
+        checker().verifyEquals("Invalid value for Comments/Special Instructions ", "Ho Ho Ho", requestPage2.getSpecialInstructions());
         checker().verifyEquals("Invalid value for Shipping Destination", "456 Thompson lane (Math bldg)", requestPage2.getShippingDestination());
         checker().verifyEquals("Invalid value for Delivery Attention to ", "Mrs Claus", requestPage2.getDeliveryAttentionTo());
         checker().verifyEquals("Invalid value for Line Item ", "Pen", requestPage2.getItemDesc());
@@ -951,8 +951,8 @@ public class WNPRC_PurchasingTest extends BaseWebDriverTest implements PostgresO
                 .setUnitCost(request.get("Unit Cost"))
                 .setQuantity(request.get("Quantity"));
 
-        if (request.containsKey("Special instructions"))
-            requestPage.setSpecialInstructions(request.get("Special instructions"));
+        if (request.containsKey("Comments/Special instructions"))
+            requestPage.setSpecialInstructions(request.get("Comments/Special instructions"));
 
         if (fileName != null)
             requestPage.addAttachment(fileName);


### PR DESCRIPTION
#### Rationale
Merge purchasing changes from WNPRC ticket 13035 into 21.11

#### Changes
Copied from ticket:

2) - Additional columns for end users. Are end users able to, for example, search for items purchased?
For this one the individual users do have access to the line item view here: https://ehr.primate.wisc.edu/WNPRC/WNPRC_Units/Operation_Services/WNPRC%20Purchasing/query-executeQuery.view?schemaName=ehr_purchasing&query.queryName=lineItems and it DOES filter to just their own line items! We will just add a new link to the WNPRC Purchasing Portal Page. Underneath "PURCHASING REQUESTS" we can add a link to that view called "MY PURCHASED ITEMS" that will allow people to filter and search on the items they have purchased in the past. One caveat: The link to the Order Number from that view does not work. It takes you to a list view rather than the react form. Please open a ticket with LabKey to get this fixed.

3) - Numbering the items being purchased.
This is necessary for version 1.0. We can either automatically append the "1." "2." and so on to each line when it's added, but that could cause confusion when trying to get the details about the line item, especially when it includes a number with periods in there. The better solution will be to create a new column, set it to automatically increment as new lines are added, set it to be read-only and add it to the react form. Please put together an estimate of what it would take to accomplish this and it will either be done in house or contracted to LabKey.

5) - Changing "Special Instructions" to "Comments/Special Instructions"
An easy change we can apply for version 1.0