### PR TITLE
Updating jdbc driver for 21.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@ WNPRC_EHR/resources/web/wnprc_ehr/model/sources/Encounter.js -text
 WNPRC_EHR/resources/views/help.html -text
 WNPRC_EHR/resources/views/userFeedback.html -text
 WNPRC_EHR/resources/views/wnprcLabs.html -text
+
+docker/tomcat/ROOT.xml -text

--- a/docker/tomcat/ROOT.xml
+++ b/docker/tomcat/ROOT.xml
@@ -24,7 +24,7 @@
               type="javax.sql.DataSource"
               username="${msql.user}"
               password="${msql.pass}"
-              driverClassName="com.mysql.jdbc.Driver"
+              driverClassName="com.mysql.cj.jdbc.Driver"
               url="${msql.url}"
               maxTotal="15"
               maxIdle="7"


### PR DESCRIPTION
#### Rationale
Mariadb is having a problem in 21.11 want to make sure it is not related to the port we are using to test the server.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
