### PR TITLE
Fix to go with ehr viral load assay precision issue

### DIFF
--- a/WNPRC_EHR/resources/assay/Viral_Loads/queries/Data.query.xml
+++ b/WNPRC_EHR/resources/assay/Viral_Loads/queries/Data.query.xml
@@ -61,6 +61,7 @@
                         <description>This is the volume or mass of the source material. If it is a batched sample enter the volume of a single sample (most likely 0.1mL).</description>
                         <measure>false</measure>
                         <dimension>false</dimension>
+                        <formatString>##.###</formatString>
                     </column>
                     <column columnName="dilutionFactor">
                         <columnTitle>Dilution Factor</columnTitle>

--- a/WNPRC_EHR/resources/assay/Viral_Loads/queries/Data.query.xml
+++ b/WNPRC_EHR/resources/assay/Viral_Loads/queries/Data.query.xml
@@ -61,7 +61,7 @@
                         <description>This is the volume or mass of the source material. If it is a batched sample enter the volume of a single sample (most likely 0.1mL).</description>
                         <measure>false</measure>
                         <dimension>false</dimension>
-                        <formatString>##.###</formatString>
+                        <formatString>.###</formatString>
                     </column>
                     <column columnName="dilutionFactor">
                         <columnTitle>Dilution Factor</columnTitle>


### PR DESCRIPTION
#### Rationale
Previously the viral load assay sampleVol column was rounding up to 2 decimals, this should respect decimal precision to 3 digits.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/385

#### Changes
* add formatString to metadata xml file
