### PR TITLE
Lock down the protocol fields a bit

### DIFF
--- a/WNPRC_EHR/resources/queries/ehr/protocol.query.xml
+++ b/WNPRC_EHR/resources/queries/ehr/protocol.query.xml
@@ -6,6 +6,52 @@
                     <column columnName="maxAnimals">
                         <columnTitle>Max Animals</columnTitle>
                         <formatString>####</formatString>
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="protocol">
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="title">
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="inves">
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="investigatorId">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="approve">
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="lastAnnualReview">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="enddate">
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="first_approval">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="project_type">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="external_id">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="ibc_approval_required">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="ibc_approval_num">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="usda_level">
+                        <isReadOnly>true</isReadOnly>
+                    </column>
+                    <column columnName="last_modification">
+                        <isUserEditable>false</isUserEditable>
+                    </column>
+                    <column columnName="description">
+                        <isUserEditable>false</isUserEditable>
                     </column>
                 </columns>
             </table>


### PR DESCRIPTION
#### Rationale
Only the 'contacts' field should be editable, the rest should come from arrow ETL.

#### Related Pull Requests
* https://github.com/WNPRC-EHR-Services/wnprc-modules/pull/291

#### Changes
* Edit the protocol query xml to restrict editing protocol fields
