### PR TITLE
Improving alert to use LocalDateTime and remove PM in the morning alert

### DIFF
--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/WaterOrdersAlertNotification.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/WaterOrdersAlertNotification.java
@@ -74,11 +74,11 @@ public class WaterOrdersAlertNotification extends AbstractEHRNotification
     }
 
     private void findWaterOrdersNotCompleted(Container c,User u, StringBuilder msg, final LocalDateTime maxDate, boolean includeFuture){
-        LocalDateTime currentTime = LocalDateTime.of(maxDate.toLocalDate(), maxDate.toLocalTime());
+        LocalDateTime currentTime = maxDate;
         LocalDateTime amThreshold = LocalDateTime.now().withHour(10).withMinute(30);
 
         //Setting interval to start the water schedule, the system generates the calendar thirty days before
-        LocalDateTime roundedMax = LocalDateTime.of(maxDate.toLocalDate(), maxDate.toLocalTime());
+        LocalDateTime roundedMax = maxDate;
         roundedMax = roundedMax.plusDays(-5).truncatedTo(ChronoUnit.DAYS);
 
         //final String intervalLength = "10";
@@ -94,7 +94,7 @@ public class WaterOrdersAlertNotification extends AbstractEHRNotification
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("QCState/label"),"Scheduled",CompareType.EQUAL);
 
         if (includeFuture){
-            LocalDateTime futureDate = LocalDateTime.of(maxDate.toLocalDate(), maxDate.toLocalTime());
+            LocalDateTime futureDate = maxDate;
             futureDate = futureDate.plusDays(1).truncatedTo(ChronoUnit.DAYS);
 
             filter.addCondition(FieldKey.fromString("dateOrdered"),futureDate, CompareType.LTE);

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/WaterOrdersAlertNotification.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/notification/WaterOrdersAlertNotification.java
@@ -1,5 +1,4 @@
 package org.labkey.wnprc_ehr.notification;
-import org.apache.commons.lang3.time.DateUtils;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -12,14 +11,11 @@ import org.labkey.api.module.Module;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
-import org.labkey.api.util.DateUtil;
-
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -70,45 +66,42 @@ public class WaterOrdersAlertNotification extends AbstractEHRNotification
         final Date now = new Date();
 
         msg.append("This email contains any water orders not marked as completed.  It was run on: " + _dateFormat.format(now) + " at " + _timeFormat.format(now) + ".<p>");
-        findWaterOrdersNotCompleted(c,u,msg,new Date(), false);
-        findWaterOrdersNotCompleted(c,u,msg,new Date(), true);
+        findWaterOrdersNotCompleted(c,u,msg,LocalDateTime.now(), false);
+        findWaterOrdersNotCompleted(c,u,msg,LocalDateTime.now(), true);
 
         return msg.toString();
 
     }
 
-    private void findWaterOrdersNotCompleted(Container c,User u, StringBuilder msg, final Date maxDate, boolean includeFuture){
-        Calendar currentTime = Calendar.getInstance();
-        currentTime.setTime(maxDate);
+    private void findWaterOrdersNotCompleted(Container c,User u, StringBuilder msg, final LocalDateTime maxDate, boolean includeFuture){
+        LocalDateTime currentTime = LocalDateTime.of(maxDate.toLocalDate(), maxDate.toLocalTime());
+        LocalDateTime amThreshold = LocalDateTime.now().withHour(10).withMinute(30);
 
         //Setting interval to start the water schedule, the system generates the calendar thirty days before
-        Date roundedMax = new Date();
-        roundedMax.setTime(maxDate.getTime());
-        roundedMax = DateUtils.addDays(roundedMax, -5);
-        roundedMax = DateUtils.truncate(roundedMax, Calendar.DATE);
+        LocalDateTime roundedMax = LocalDateTime.of(maxDate.toLocalDate(), maxDate.toLocalTime());
+        roundedMax = roundedMax.plusDays(-5).truncatedTo(ChronoUnit.DAYS);
 
         //final String intervalLength = "10";
 
         //Sending parameters to the query that generates the water schedule from water orders and water amounts
         Map<String, Object> parameters = new CaseInsensitiveHashMap<>();
         parameters.put("NumDays", 6);
-        parameters.put("StartDate", roundedMax);
+        //static DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+        String dateFormat = roundedMax.format(DateTimeFormatter.ISO_DATE_TIME);
+        parameters.put("StartDate", roundedMax.toString());
 
         TableInfo ti = QueryService.get().getUserSchema(u,c,"study").getTable("waterScheduleCoalesced");
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("QCState/label"),"Scheduled",CompareType.EQUAL);
 
         if (includeFuture){
-            Date futureDate = new Date();
-            futureDate.setTime(maxDate.getTime());
-            futureDate = DateUtils.addDays(futureDate,1);
-            futureDate = DateUtils.truncate(futureDate, Calendar.DATE);
-            //currentTime.add(Calendar.DATE,1);
+            LocalDateTime futureDate = LocalDateTime.of(maxDate.toLocalDate(), maxDate.toLocalTime());
+            futureDate = futureDate.plusDays(1).truncatedTo(ChronoUnit.DAYS);
 
             filter.addCondition(FieldKey.fromString("dateOrdered"),futureDate, CompareType.LTE);
-            filter.addCondition(FieldKey.fromString("dateOrdered"),currentTime.getTime(), CompareType.GT);
+            filter.addCondition(FieldKey.fromString("dateOrdered"),currentTime, CompareType.GT);
 
         }else{
-            filter.addCondition(FieldKey.fromString("dateOrdered"),currentTime.getTime(), CompareType.LTE);
+            filter.addCondition(FieldKey.fromString("dateOrdered"),currentTime, CompareType.LTE);
         }
 
         filter.addCondition(FieldKey.fromString("dateOrdered"), roundedMax,CompareType.DATE_GTE);
@@ -132,10 +125,15 @@ public class WaterOrdersAlertNotification extends AbstractEHRNotification
         ts.setNamedParameters(parameters);
         long total = ts.getRowCount();
 
+        String timeofday = "AM";
+        if (currentTime.isAfter(amThreshold)){
+            timeofday = "PM";
+        }
+
         if (total == 0 && !includeFuture){
-            msg.append("All water orders are completed");
-        }else{
-            if(includeFuture){
+            msg.append("All " + timeofday + " water orders are completed");
+        }else if(total > 0){
+            if(includeFuture && timeofday.equals("PM")){
                 msg.append("<p><b>There are "+total+ " water orders that are scheduled for today and have not been completed</b><br>");
             }else{
                 msg.append("<p><b>WARNING: There are "+total+ " water orders that have not been completed</b><br>");
@@ -178,7 +176,7 @@ public class WaterOrdersAlertNotification extends AbstractEHRNotification
 
             }
             msg.append("<br><a href='" + getExecuteQueryUrl(c,"study","waterScheduleCoalesced","Scheduled")+"&query.param.StartDate="+roundedMax+"&query.param.NumDays=" + 1 +
-                    "&query.dateOrdered~lte="+currentTime.getTime()+ "&query.dateOrdered~dategte="+roundedMax+"'>Click here to view schedule waters</a></p>");
+                    "&query.dateOrdered~lte="+currentTime+ "&query.dateOrdered~dategte="+roundedMax+"'>Click here to view schedule waters</a></p>");
         }
 
 


### PR DESCRIPTION
#### Rationale
User was interested in not getting schedule orders in the AM, but staring to get them in the afternoon.
 
#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- change dates and calendar to use LocalDateTime
- add a amTreshhold variable to determine if PM orders should be included
