### PR TITLE
22.7 fb tls email

### DIFF
--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.004-21.005.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.004-21.005.sql
@@ -1,2 +1,2 @@
-alter table wnprc.animal_requests if exists add column externalthreadrowid integer;
-alter table wnprc.animal_requests if exists add column internalthreadrowid integer;
+alter table if exists wnprc.animal_requests  add column externalthreadrowid integer;
+alter table if exists wnprc.animal_requests  add column internalthreadrowid integer;

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.004-21.005.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.004-21.005.sql
@@ -1,2 +1,2 @@
-alter table wnprc.animal_requests add column externalthreadrowid integer;
-alter table wnprc.animal_requests add column internalthreadrowid integer;
+alter table wnprc.animal_requests if exists add column externalthreadrowid integer;
+alter table wnprc.animal_requests if exists add column internalthreadrowid integer;

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.000-22.001.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-22.000-22.001.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS wnprc.session_log
+(
+    rowid                   serial NOT NULL,
+    start_time              TIMESTAMP,
+    end_time                TIMESTAMP,
+    schema_name             varchar(100),
+    query_name              varchar(100),
+    task_id                 varchar(255),
+    number_of_records       integer,
+    batch_add_used          boolean,
+    bulk_edit_used          boolean,
+    user_agent              varchar(255),
+    errors_occurred         boolean,
+    form_framework_type     integer,
+
+    -- Default fields for LabKey.
+    container         entityid NOT NULL,
+    createdby         userid,
+    created           TIMESTAMP,
+    modifiedby        userid,
+    modified          TIMESTAMP,
+
+    CONSTRAINT pk_session_log_rowid PRIMARY KEY (rowid),
+    CONSTRAINT fk_session_log_form_framework_type FOREIGN KEY (form_framework_type) REFERENCES ehr.form_framework_types (rowid)
+);
+

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 21.006;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 22.001;
     }
 
     @Override

--- a/WNPRC_r24/src/org/labkey/wnprc_r24/wnprc_r24Module.java
+++ b/WNPRC_r24/src/org/labkey/wnprc_r24/wnprc_r24Module.java
@@ -46,7 +46,7 @@ public class wnprc_r24Module extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 20.000;
+        return 22.000;
     }
 
     @Override

--- a/WNPRC_u24/src/org/labkey/wnprc_u24/wnprc_u24Module.java
+++ b/WNPRC_u24/src/org/labkey/wnprc_u24/wnprc_u24Module.java
@@ -46,7 +46,7 @@ public class wnprc_u24Module extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 21.300;
+        return 22.000;
     }
 
     @Override

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
 
   postgres:
-    image: postgres:11
+    image: postgres:12
     container_name: postgres
     shm_size: 4g
     restart: always

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -7,6 +7,7 @@ ARG LABKEY_TEAMCITY_PASSWORD
 ARG LABKEY_TEAMCITY_USERNAME
 ARG WNPRC_BRANCH=master
 ARG LABKEY_VERSION
+ARG GENERAL_LK_VERSION
 ARG LABKEY_IS_PREMIUM=true
 
 WORKDIR /tmp/labkey
@@ -29,6 +30,12 @@ RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B=""
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     elif [ "$LABKEY_VERSION" = 21.11 ] ; then \
         LABKEY_TEAMCITY_CONFIG="LabKey_2111Release_External_Wnprc_Installers2" ; \
+        LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
+        LABKEY_DISTRIBUTION="wisc" ; \
+        LABKEY_FILE_NAME="UWisc.tar.gz" ; \
+    else  \
+        GENERAL_LK_VERSION = "${LABKEY_VERSION//.} \
+        LABKEY_TEAMCITY_CONFIG="LabKey_"+ $GENERAL_LK_VERSION + "Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -18,8 +18,8 @@ RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
 RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
-    && echo -e "LabKeyVersion: "${LABKEY_VERSION}; \
-    && echo -e "value of B: " ${B}; \
+     echo -e "LabKeyVersion: "${LABKEY_VERSION}; \
+     echo -e "value of B: " ${B}; \
  && if [[  ! -z "$LABKEY_VERSION" ]] ; then \
         echo -e "No LabKey version, building trunk ";\
         LABKEY_TEAMCITY_CONFIG="LabKey_Trunk_External_Wnprc_Installers_2" ; \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -7,7 +7,6 @@ ARG LABKEY_TEAMCITY_PASSWORD
 ARG LABKEY_TEAMCITY_USERNAME
 ARG WNPRC_BRANCH=master
 ARG LABKEY_VERSION
-ARG GENERAL_LK_VERSION
 ARG LABKEY_IS_PREMIUM=true
 
 WORKDIR /tmp/labkey
@@ -18,10 +17,8 @@ RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
 RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
-     echo -e "LabKeyVersion: "${LABKEY_VERSION}; \
-     echo -e "value of B: " ${B}; \
- && if [[  ! -z "$LABKEY_VERSION" ]] ; then \
-        echo -e "No LabKey version, building trunk ";\
+ && if [ -z "$LABKEY_VERSION" ] ; then \
+         echo -e "No LabKey version, building trunk ";\
         LABKEY_TEAMCITY_CONFIG="LabKey_Trunk_External_Wnprc_Installers_2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \
@@ -37,9 +34,9 @@ RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B=""
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
-        echo -e "LabKey Version: " + ${LABKEY_VERSION};   \
-        GENERAL_LK_VERSION = "$LABKEY_VERSION";      \
-        LABKEY_TEAMCITY_CONFIG="LabKey_"+ $GENERAL_LK_VERSION + "Release_External_Wnprc_Installers2" ; \
+         echo -e "LabKey Version: " ${LABKEY_VERSION}; \
+        GENERAL_LK_VERSION=${LABKEY_VERSION//./}; \
+        LABKEY_TEAMCITY_CONFIG="LabKey_${GENERAL_LK_VERSION}Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -34,7 +34,8 @@ RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B=""
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
-        GENERAL_LK_VERSION = "${LABKEY_VERSION//.}" \
+        echo "LabKey Version " + $LABKEY_VERSION;   \
+        GENERAL_LK_VERSION = "$LABKEY_VERSION";      \
         LABKEY_TEAMCITY_CONFIG="LabKey_"+ $GENERAL_LK_VERSION + "Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -18,6 +18,8 @@ RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
 RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
+    && echo -e "LabKeyVersion: "${LABKEY_VERSION} \
+    && echo -e "value of B: " ${B} \
  && if [[  ! -z "$LABKEY_VERSION" ]] ; then \
         LABKEY_TEAMCITY_CONFIG="LabKey_Trunk_External_Wnprc_Installers_2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
@@ -34,7 +36,7 @@ RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B=""
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
-        echo "LabKey Version " + $LABKEY_VERSION;   \
+        echo -e "LabKey Version " + $LABKEY_VERSION;   \
         GENERAL_LK_VERSION = "$LABKEY_VERSION";      \
         LABKEY_TEAMCITY_CONFIG="LabKey_"+ $GENERAL_LK_VERSION + "Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -17,7 +17,7 @@ ARG LABKEY_TEAMCITY_BUILD=
 RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
-RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
+RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:${WNPRC_BRANCH}"; fi \
     && echo -e "LabKeyVersion: "${LABKEY_VERSION} \
     && echo -e "value of B: " ${B} \
  && if [[  ! -z "$LABKEY_VERSION" ]] ; then \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -17,10 +17,11 @@ ARG LABKEY_TEAMCITY_BUILD=
 RUN apk update \
     && apk add --no-cache wget tar ca-certificates && update-ca-certificates
 
-RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:${WNPRC_BRANCH}"; fi \
-    && echo -e "LabKeyVersion: "${LABKEY_VERSION} \
-    && echo -e "value of B: " ${B} \
+RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B="" ; else B=",branch:"${WNPRC_BRANCH}; fi \
+    && echo -e "LabKeyVersion: "${LABKEY_VERSION}; \
+    && echo -e "value of B: " ${B}; \
  && if [[  ! -z "$LABKEY_VERSION" ]] ; then \
+        echo -e "No LabKey version, building trunk ";\
         LABKEY_TEAMCITY_CONFIG="LabKey_Trunk_External_Wnprc_Installers_2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \
@@ -36,7 +37,7 @@ RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B=""
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
-        echo -e "LabKey Version " + $LABKEY_VERSION;   \
+        echo -e "LabKey Version: " + ${LABKEY_VERSION};   \
         GENERAL_LK_VERSION = "$LABKEY_VERSION";      \
         LABKEY_TEAMCITY_CONFIG="LabKey_"+ $GENERAL_LK_VERSION + "Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \

--- a/docker/labkey/Dockerfile
+++ b/docker/labkey/Dockerfile
@@ -34,7 +34,7 @@ RUN if [ "$WNPRC_BRANCH" = "master" || "$WNPRC_BRANCH" = "develop" ] ; then B=""
         LABKEY_DISTRIBUTION="wisc" ; \
         LABKEY_FILE_NAME="UWisc.tar.gz" ; \
     else  \
-        GENERAL_LK_VERSION = "${LABKEY_VERSION//.} \
+        GENERAL_LK_VERSION = "${LABKEY_VERSION//.}" \
         LABKEY_TEAMCITY_CONFIG="LabKey_"+ $GENERAL_LK_VERSION + "Release_External_Wnprc_Installers2" ; \
         LABKEY_SNAPSHOT="-SNAPSHOT-" ; \
         LABKEY_DISTRIBUTION="wisc" ; \

--- a/docker/manage_all_containers.sh
+++ b/docker/manage_all_containers.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+dev_regex="^dev(.*)"
+
+args=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -s|--start)
+      start=true
+      shift
+      ;;
+    -d|--down)
+     start=false
+     shift
+     ;;
+   *) ## positional arguments
+       args+=("$1")
+       shift
+         ;;
+   esac
+ done
+ set -- "${args[@]}"
+
+function isTrue() {
+   if [[ "${@^^}" =~ ^(TRUE|OUI|Y|O$|ON$|[1-9]) ]]; then return 0;fi
+   return 1
+}
+
+listOfDevFolders=()
+shopt -s nullglob
+for f in *; do
+  ##echo -n 'list of folders '
+  #echo "${#listOfDevFolders[@]}"
+  if [[ $f =~ $dev_regex ]]; then
+    echo $f
+    listOfDevFolders+=("$f")
+  fi
+
+done
+
+if $start; then
+    echo -n 'Starting main docker-compose file'
+    docker-compose -f docker-compose.yml up -d
+
+    for folder in "${listOfDevFolders[@]}"
+    do
+      echo -n 'Staring containers in ' $folder
+      docker-compose -f $folder/docker-compose.yml up -d
+    done
+else
+  for folder in "${listOfDevFolders[@]}"
+  do
+    echo 'Stoping containers in ' $folder
+    docker-compose -f $folder/docker-compose.yml down
+  done
+
+  echo -n 'Stoping main docker-compose file'
+  docker-compose -f docker-compose.yml down
+fi

--- a/docker/manage_all_containers.sh
+++ b/docker/manage_all_containers.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+##Regex value to identified all folders that start with dev*
 dev_regex="^dev(.*)"
 
 args=()
@@ -21,21 +22,14 @@ while [[ $# -gt 0 ]]; do
  done
  set -- "${args[@]}"
 
-function isTrue() {
-   if [[ "${@^^}" =~ ^(TRUE|OUI|Y|O$|ON$|[1-9]) ]]; then return 0;fi
-   return 1
-}
-
+##Getting list of folders with dev in front
 listOfDevFolders=()
 shopt -s nullglob
 for f in *; do
-  ##echo -n 'list of folders '
-  #echo "${#listOfDevFolders[@]}"
   if [[ $f =~ $dev_regex ]]; then
     echo $f
     listOfDevFolders+=("$f")
   fi
-
 done
 
 if $start; then
@@ -50,10 +44,10 @@ if $start; then
 else
   for folder in "${listOfDevFolders[@]}"
   do
-    echo 'Stoping containers in ' $folder
+    echo 'Stopping containers in ' $folder
     docker-compose -f $folder/docker-compose.yml down
   done
 
-  echo -n 'Stoping main docker-compose file'
+  echo -n 'Stopping main docker-compose file'
   docker-compose -f docker-compose.yml down
 fi


### PR DESCRIPTION
#### Rationale
Improving docker containers management in the test server. Adding a script that can start and stop all containers in the test server.
Making the docker build version agnostic, now the version number will be determine by the tag name.

#### Related Pull Requests
none

#### Changes
- adding manage_all_containers.sh in the docker folder
- modifying docker build for LabKey to determine the labkey version based on the tag generated by teamcity.
