### PR TITLE
21.11 fb assigns v1 4

### DIFF
--- a/AnimalRequests/README.md
+++ b/AnimalRequests/README.md
@@ -37,6 +37,18 @@ More information about how the entire form works can be found in the documentati
 
 ## Release Notes
 
+### 1.4.0
+* Added new fields:
+  * Terminal for Dam (if pregnant)
+  * Terminal for Infant (if prengnat)
+  * Contacts
+  * Major Surgeries
+  * Unwanted Previous Exposures
+* Ajusted selenium test (included with virology PR)
+
+### 1.3.0
+* Added arrow connection
+
 ### 1.2.0
 
 #### Features

--- a/AnimalRequests/src/client/containers/Forms/AnimalRequestForm.tsx
+++ b/AnimalRequests/src/client/containers/Forms/AnimalRequestForm.tsx
@@ -280,323 +280,331 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                         <form onSubmit={handleSubmit}>
                                             {loading && <div className="loading" />}
                                             <div style={{display:display}} className="card-body">
-                                                <Field
-                                                    name="principalinvestigator"
-                                                    label="PI"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="uniqueProtocolInvestigator" rowkey="inves"/>
-                                                            <option value="other">Other</option>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <Condition when="principalinvestigator" is="other">
-                                                    <Field
-                                                        name="externalprincipalinvestigator"
-                                                        component={renderField}
-                                                        label="Specify PI"
-                                                        type="text"
-                                                        validate={required}
-                                                        required={true}
-                                                    >
-                                                    </Field>
-                                                </Condition>
-                                                <Field
-                                                    name="numberofanimals"
-                                                    component={renderField}
-                                                    label="# of Animals"
-                                                    type="number"
-                                                    min="1"
-                                                    validate={required}
-                                                    required={true}
-                                                    tooltip="Please provide the number of animals needed (integers only)."
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="speciesneeded"
-                                                    label="Species"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_species" rowkey="common"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <ConditionIsNot when="speciesneeded" isnot="Marmoset">
-                                                <Field
-                                                    name="originneeded"
-                                                    label="Origin"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_origin" rowkey="meaning"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                </ConditionIsNot>
-                                                <Field
-                                                    name="sex"
-                                                    label="Sex"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_sex" rowkey="value"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="age"
-                                                    component={renderField}
-                                                    label="Age"
-                                                    type="text"
-                                                    validate={required}
-                                                    required={true}
-                                                    tooltip="Please provide an approximate age range for the animals requested."
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="weight"
-                                                    component={renderField}
-                                                    label="Weight (kg)"
-                                                    type="text"
-                                                    validate={required}
-                                                    required={true}
-                                                    tooltip="Please provide an approximate weight range for the animals requested."
-                                                >
-                                                </Field>
-                                                <ConditionIsNot when="speciesneeded" isnot="Marmoset">
-                                                <Field
-                                                    name="mhctype"
-                                                    component={renderField}
-                                                    label="MHC Type"
-                                                    type="text"
-                                                    validate={required}
-                                                    required={true}
-                                                >
-                                                </Field>
-                                                </ConditionIsNot>
-                                                <ConditionIsNot when="speciesneeded" isnot="Marmoset">
-                                                <Field
-                                                    name="viralstatus"
-                                                    label="Viral Status"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_viral_status" rowkey="value"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                </ConditionIsNot>
+                                                <div className="row">
+                                                    <div className="col-xs-6">
+                                                        <Field
+                                                            name="principalinvestigator"
+                                                            label="PI"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="uniqueProtocolInvestigator" rowkey="inves"/>
+                                                                    <option value="other">Other</option>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <Condition when="principalinvestigator" is="other">
+                                                            <Field
+                                                                name="externalprincipalinvestigator"
+                                                                component={renderField}
+                                                                label="Specify PI"
+                                                                type="text"
+                                                                validate={required}
+                                                                required={true}
+                                                            >
+                                                            </Field>
+                                                        </Condition>
+                                                        <Field
+                                                            name="numberofanimals"
+                                                            component={renderField}
+                                                            label="# of Animals"
+                                                            type="number"
+                                                            min="1"
+                                                            validate={required}
+                                                            required={true}
+                                                            tooltip="Please provide the number of animals needed (integers only)."
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="speciesneeded"
+                                                            label="Species"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_species" rowkey="common"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <ConditionIsNot when="speciesneeded" isnot="Marmoset">
+                                                        <Field
+                                                            name="originneeded"
+                                                            label="Origin"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_origin" rowkey="meaning"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        </ConditionIsNot>
+                                                        <Field
+                                                            name="sex"
+                                                            label="Sex"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_sex" rowkey="value"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="age"
+                                                            component={renderField}
+                                                            label="Age"
+                                                            type="text"
+                                                            validate={required}
+                                                            required={true}
+                                                            tooltip="Please provide an approximate age range for the animals requested."
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="weight"
+                                                            component={renderField}
+                                                            label="Weight (kg)"
+                                                            type="text"
+                                                            validate={required}
+                                                            required={true}
+                                                            tooltip="Please provide an approximate weight range for the animals requested."
+                                                        >
+                                                        </Field>
+                                                        <ConditionIsNot when="speciesneeded" isnot="Marmoset">
+                                                        <Field
+                                                            name="mhctype"
+                                                            component={renderField}
+                                                            label="MHC Type"
+                                                            type="text"
+                                                            validate={required}
+                                                            required={true}
+                                                        >
+                                                        </Field>
+                                                        </ConditionIsNot>
+                                                        <ConditionIsNot when="speciesneeded" isnot="Marmoset">
+                                                        <Field
+                                                            name="viralstatus"
+                                                            label="Viral Status"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_viral_status" rowkey="value"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        </ConditionIsNot>
 
-                                                <Field
-                                                    name="infectiousdisease"
-                                                    label="Infectious Disease"
-                                                    tooltip="Is this an infectious disease project?"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_infectiousdisease" rowkey="value"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="majorsurgery"
-                                                    label="Major Surgery?"
-                                                    tooltip="Whether or not the animals are going to have major surgery on the project."
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <Field
-                                                  name="pregnantanimalsrequired"
-                                                  label="Pregnant Animals Required?"
-                                                  component={renderSelectField}
-                                                  validate={required}
-                                                  required={true}
-                                                  options={
-                                                      <>
-                                                          <option/>
-                                                          <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
-                                                      </>
-                                                  }
-                                                >
-                                                </Field>
-                                                <Condition when="pregnantanimalsrequired" is="Yes">
-                                                    <Field
-                                                        name="pregnantanimalsrequiredtermdam"
-                                                        label="Terminal For Dam?"
-                                                        component={renderSelectField}
-                                                        validate={required}
-                                                        required={true}
-                                                        options={
-                                                            <>
-                                                                <option/>
-                                                                <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
-                                                            </>
-                                                        }
-                                                    >
-                                                    </Field>
-                                                </Condition>
-                                                <Condition when="pregnantanimalsrequired" is="Yes">
-                                                    <Field
-                                                        name="pregnantanimalsrequiredterminfant"
-                                                        label="Terminal For Infant?"
-                                                        component={renderSelectField}
-                                                        validate={required}
-                                                        required={true}
-                                                        options={
-                                                            <>
-                                                                <option/>
-                                                                <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
-                                                            </>
-                                                        }
-                                                    >
-                                                    </Field>
-                                                </Condition>
-                                                <Field
-                                                    name="disposition"
-                                                    label="Disposition"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <DropdownOptions name="animal_requests_disposition" rowkey="value"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="previousexposures"
-                                                    label="Unwanted Previous Exposures"
-                                                    tooltip="List which exposures you do not want the animals exposed to."
-                                                    component={renderField}
-                                                    type="text"
-                                                    required={false}
-                                                >
-                                                </Field>
-                                                <Field
-                                                  name="executivecommitteeapproval"
-                                                  label="Executive Committee Approval?"
-                                                  component={renderSelectField}
-                                                  validate={required}
-                                                  required={true}
-                                                  options={
-                                                      <>
-                                                          <option/>
-                                                          <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
-                                                      </>
-                                                  }
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="optionalproject"
-                                                    label="Project"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <option value="TBD">TBD</option>
-                                                            <DropdownOptions name="animal_requests_active_projects" rowkey="project"/>
-                                                        </>
-                                                    }
-                                                >
+                                                        <Field
+                                                            name="infectiousdisease"
+                                                            label="Infectious Disease"
+                                                            tooltip="Is this an infectious disease project?"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_infectiousdisease" rowkey="value"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="majorsurgery"
+                                                            label="Major Surgery?"
+                                                            tooltip="Whether or not the animals are going to have major surgery on the project."
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                          name="pregnantanimalsrequired"
+                                                          label="Pregnant Animals Required?"
+                                                          component={renderSelectField}
+                                                          validate={required}
+                                                          required={true}
+                                                          options={
+                                                              <>
+                                                                  <option/>
+                                                                  <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                              </>
+                                                          }
+                                                        >
+                                                        </Field>
+                                                        <Condition when="pregnantanimalsrequired" is="Yes">
+                                                            <Field
+                                                                name="pregnantanimalsrequiredtermdam"
+                                                                label="Terminal For Dam?"
+                                                                component={renderSelectField}
+                                                                validate={required}
+                                                                required={true}
+                                                                options={
+                                                                    <>
+                                                                        <option/>
+                                                                        <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                                    </>
+                                                                }
+                                                            >
+                                                            </Field>
+                                                        </Condition>
+                                                        <Condition when="pregnantanimalsrequired" is="Yes">
+                                                            <Field
+                                                                name="pregnantanimalsrequiredterminfant"
+                                                                label="Terminal For Infant?"
+                                                                component={renderSelectField}
+                                                                validate={required}
+                                                                required={true}
+                                                                options={
+                                                                    <>
+                                                                        <option/>
+                                                                        <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                                    </>
+                                                                }
+                                                            >
+                                                            </Field>
+                                                        </Condition>
+                                                        <Field
+                                                            name="disposition"
+                                                            label="Disposition"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <DropdownOptions name="animal_requests_disposition" rowkey="value"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="previousexposures"
+                                                            label="Unwanted Previous Exposures"
+                                                            tooltip="List which exposures you do not want the animals exposed to."
+                                                            component={renderField}
+                                                            type="text"
+                                                            required={false}
+                                                        >
+                                                        </Field>
+                                                    </div>
+                                                    <div className="col-xs-6">
+                                                        <Field
+                                                          name="executivecommitteeapproval"
+                                                          label="Executive Committee Approval?"
+                                                          component={renderSelectField}
+                                                          validate={required}
+                                                          required={true}
+                                                          options={
+                                                              <>
+                                                                  <option/>
+                                                                  <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                              </>
+                                                          }
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="optionalproject"
+                                                            label="Project"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <option value="TBD">TBD</option>
+                                                                    <DropdownOptions name="animal_requests_active_projects" rowkey="project"/>
+                                                                </>
+                                                            }
+                                                        >
 
-                                                </Field>
-                                                <Field
-                                                  name="account"
-                                                  label="Account"
-                                                  component={renderField}
-                                                  type="text"
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="protocol"
-                                                    label="Protocol"
-                                                    component={renderSelectField}
-                                                    validate={required}
-                                                    required={true}
-                                                    options={
-                                                        <>
-                                                            <option/>
-                                                            <option value="TBD">TBD</option>
-                                                            <DropdownOptions name="protocol" rowkey="protocol"/>
-                                                        </>
-                                                    }
-                                                >
-                                                </Field>
-                                                <Field
-                                                  name="anticipatedstartdate"
-                                                  id="anticipatedstartdate"
-                                                  label="Anticipated Start Date"
-                                                  component={renderDateTimePicker}
-                                                  type="text"
-                                                  validate={required}
-                                                >
+                                                        </Field>
+                                                        <Field
+                                                          name="account"
+                                                          label="Account"
+                                                          component={renderField}
+                                                          type="text"
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="protocol"
+                                                            label="Protocol"
+                                                            component={renderSelectField}
+                                                            validate={required}
+                                                            required={true}
+                                                            options={
+                                                                <>
+                                                                    <option/>
+                                                                    <option value="TBD">TBD</option>
+                                                                    <DropdownOptions name="protocol" rowkey="protocol"/>
+                                                                </>
+                                                            }
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                          name="anticipatedstartdate"
+                                                          id="anticipatedstartdate"
+                                                          label="Anticipated Start Date"
+                                                          component={renderDateTimePicker}
+                                                          type="text"
+                                                          validate={required}
+                                                        >
 
-                                                </Field>
-                                                <Field
-                                                  name="anticipatedenddate"
-                                                  id="anticipatedenddate"
-                                                  label="Anticipated End Date"
-                                                  component={renderDateTimePicker}
-                                                  type="text"
-                                                  validate={required}
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="comments"
-                                                    label="Comments"
-                                                    component={renderTextArea}
-                                                    type="textarea"
-                                                    required={false}
-                                                >
-                                                </Field>
-                                                <Field
-                                                    name="contacts"
-                                                    label="Contacts"
-                                                    component={renderTextArea}
-                                                    type="textarea"
-                                                    required={false}
-                                                    tooltip="List any contacts for this request (names, emails, etc)."
-                                                >
-                                                </Field>
+                                                        </Field>
+                                                        <Field
+                                                          name="anticipatedenddate"
+                                                          id="anticipatedenddate"
+                                                          label="Anticipated End Date"
+                                                          component={renderDateTimePicker}
+                                                          type="text"
+                                                          validate={required}
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="comments"
+                                                            label="Comments"
+                                                            component={renderTextArea}
+                                                            type="textarea"
+                                                            required={false}
+                                                        >
+                                                        </Field>
+                                                        <Field
+                                                            name="contacts"
+                                                            label="Contacts"
+                                                            component={renderTextArea}
+                                                            type="textarea"
+                                                            required={false}
+                                                            tooltip="List any contacts for this request (names, emails, etc)."
+                                                        >
+                                                        </Field>
+                                                    </div>
+                                                </div>
                                             </div>
+                                            <br/>
+                                            <p>{formDescription}</p>
                                             <div className="row top-buffer">
                                                 <div className="btn-wrap">
                                                     <button
@@ -604,7 +612,7 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                                         id="submit-final"
                                                         disabled={this.state.submitted}
                                                         type="submit"
-                                                        >
+                                                    >
                                                         Submit
                                                     </button>
                                                     <button
@@ -612,13 +620,11 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                                         onClick={ () => {
                                                             window.location = cancelUrl;
                                                         }}
-                                                        >
+                                                    >
                                                         Cancel
                                                     </button>
                                                 </div>
                                             </div>
-                                            <br/>
-                                            <p>{formDescription}</p>
                                         </form>
 
                                     </div>

--- a/AnimalRequests/src/client/containers/Forms/AnimalRequestForm.tsx
+++ b/AnimalRequests/src/client/containers/Forms/AnimalRequestForm.tsx
@@ -19,7 +19,7 @@ const renderField = ({
     }) => (
     <div className="row top-buffer">
         <div className={asyncValidating ? 'async-validating' : ''}>
-            <label className="col-xs-5 form-control-label"> {label}{tooltip && (<sup><span id="help-tooltip" data-tooltip={tooltip}>?️</span></sup>)}: </label>
+            <label className="col-xs-5 form-control-label"> {label}{tooltip && (<a><sup><span id="help-tooltip" data-tooltip={tooltip}>?️</span></sup></a>)}: </label>
             <input min={min} {...required==true ? required : ''} className={`col-xs-5 form-control-${type}`}  type={type} {...input} />
             {touched && ((error && <span>{error}</span>))}
         </div>
@@ -34,7 +34,7 @@ const renderSelectField = ({
     <div className="row top-buffer">
         <div className={asyncValidating ? 'async-validating' : ''}>
             <label className="col-xs-5 form-control-label"> {label}{tooltip && (
-            <sup><span id="help-tooltip" data-tooltip={tooltip}>?️</span></sup>)}: </label>
+                <a><sup><span id="help-tooltip" data-tooltip={tooltip}>?️</span></sup></a>)}: </label>
             <select {...required==true ? required : ''} className="col-xs-5 form-control-input" {...input}> {...options} </select>
             {touched && ((error && <span>{error}</span>))}
         </div>
@@ -65,7 +65,7 @@ const renderTextArea = ({
     }) => (
     <div className="row top-buffer">
         <div className={asyncValidating ? 'async-validating' : ''}>
-            <label className="col-xs-5 form-control-label"> {label}{tooltip && (<sup><span id="help-tooltip" data-tooltip={tooltip}>?️</span></sup>)}: </label>
+            <label className="col-xs-5 form-control-label"> {label}{tooltip && (<a><sup><span id="help-tooltip" data-tooltip={tooltip}>?️</span></sup></a>)}: </label>
             <textarea {...required==true ? required : ''} className={`col-xs-5 form-control-${type}`}  type={type} {...input} />
             {touched && ((error && <span>{error}</span>))}
         </div>
@@ -425,6 +425,21 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                                 >
                                                 </Field>
                                                 <Field
+                                                    name="majorsurgery"
+                                                    label="Major Surgery?"
+                                                    tooltip="Whether or not the animals are going to have major surgery on the project."
+                                                    component={renderSelectField}
+                                                    validate={required}
+                                                    required={true}
+                                                    options={
+                                                        <>
+                                                            <option/>
+                                                            <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                        </>
+                                                    }
+                                                >
+                                                </Field>
+                                                <Field
                                                   name="pregnantanimalsrequired"
                                                   label="Pregnant Animals Required?"
                                                   component={renderSelectField}
@@ -438,6 +453,38 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                                   }
                                                 >
                                                 </Field>
+                                                <Condition when="pregnantanimalsrequired" is="Yes">
+                                                    <Field
+                                                        name="pregnantanimalsrequiredtermdam"
+                                                        label="Terminal For Dam?"
+                                                        component={renderSelectField}
+                                                        validate={required}
+                                                        required={true}
+                                                        options={
+                                                            <>
+                                                                <option/>
+                                                                <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                            </>
+                                                        }
+                                                    >
+                                                    </Field>
+                                                </Condition>
+                                                <Condition when="pregnantanimalsrequired" is="Yes">
+                                                    <Field
+                                                        name="pregnantanimalsrequiredterminfant"
+                                                        label="Terminal For Infant?"
+                                                        component={renderSelectField}
+                                                        validate={required}
+                                                        required={true}
+                                                        options={
+                                                            <>
+                                                                <option/>
+                                                                <DropdownOptions name="animal_requests_yes_no" rowkey="value"/>
+                                                            </>
+                                                        }
+                                                    >
+                                                    </Field>
+                                                </Condition>
                                                 <Field
                                                     name="disposition"
                                                     label="Disposition"
@@ -450,6 +497,15 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                                             <DropdownOptions name="animal_requests_disposition" rowkey="value"/>
                                                         </>
                                                     }
+                                                >
+                                                </Field>
+                                                <Field
+                                                    name="previousexposures"
+                                                    label="Unwanted Previous Exposures"
+                                                    tooltip="List which exposures you do not want the animals exposed to."
+                                                    component={renderField}
+                                                    type="text"
+                                                    required={false}
                                                 >
                                                 </Field>
                                                 <Field
@@ -529,6 +585,15 @@ export class AnimalRequestForm extends React.Component<any,State> {
                                                     component={renderTextArea}
                                                     type="textarea"
                                                     required={false}
+                                                >
+                                                </Field>
+                                                <Field
+                                                    name="contacts"
+                                                    label="Contacts"
+                                                    component={renderTextArea}
+                                                    type="textarea"
+                                                    required={false}
+                                                    tooltip="List any contacts for this request (names, emails, etc)."
                                                 >
                                                 </Field>
                                             </div>

--- a/AnimalRequests/src/client/theme/css/index.css
+++ b/AnimalRequests/src/client/theme/css/index.css
@@ -123,7 +123,7 @@ select {
     border-radius: 1px;
     -moz-appearance: none;
     -webkit-appearance: none;
-    background: url(/labkey/_images/arrow_down.png) right no-repeat !important;
+    background: url(/_images/arrow_down.png) right no-repeat !important;
     text-transform: Capitalize !important;
 
 }
@@ -133,7 +133,7 @@ select {
     text-align: center;
     display: block;
     position: relative;
-    background: url(/labkey/_images/ajax-loading.gif) left no-repeat !important;
+    background: url(/_images/ajax-loading.gif) left no-repeat !important;
     background-size: fill;
     font-size: 2em;
     padding: 20px 0 0 0;

--- a/AnimalRequests/src/client/theme/css/index.css
+++ b/AnimalRequests/src/client/theme/css/index.css
@@ -123,7 +123,7 @@ select {
     border-radius: 1px;
     -moz-appearance: none;
     -webkit-appearance: none;
-    background: url(/_images/arrow_down.png) right no-repeat !important;
+    background: url(/labkey/_images/arrow_down.png) right no-repeat !important;
     text-transform: Capitalize !important;
 
 }
@@ -133,7 +133,7 @@ select {
     text-align: center;
     display: block;
     position: relative;
-    background: url(/_images/ajax-loading.gif) left no-repeat !important;
+    background: url(/labkey/_images/ajax-loading.gif) left no-repeat !important;
     background-size: fill;
     font-size: 2em;
     padding: 20px 0 0 0;

--- a/AnimalRequests/src/client/theme/css/index.css
+++ b/AnimalRequests/src/client/theme/css/index.css
@@ -4,7 +4,7 @@
     -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
     padding: 15px;
-    max-width: 620px;
+    max-width: 1220px;
     margin-left: 20px;
 }
 
@@ -19,7 +19,7 @@
 }
 
 .form-wrapper {
-    max-width: 600px;
+    max-width: 1200px;
 }
 
 /*override some datepicker css to get it to line up with the other fields*/

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.006-21.007.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.006-21.007.sql
@@ -1,5 +1,5 @@
-alter table wnprc.animal_requests add column pregnantanimalsrequiredterminfant varchar(100);
-alter table wnprc.animal_requests add column pregnantanimalsrequiredtermdam varchar(100);
-alter table wnprc.animal_requests add column majorsurgery varchar(100);
-alter table wnprc.animal_requests add column previousexposures text;
-alter table wnprc.animal_requests add column contacts text;
+alter table if exists wnprc.animal_requests add column pregnantanimalsrequiredterminfant varchar(100);
+alter table if exists wnprc.animal_requests add column pregnantanimalsrequiredtermdam varchar(100);
+alter table if exists wnprc.animal_requests add column majorsurgery varchar(100);
+alter table if exists wnprc.animal_requests add column previousexposures text;
+alter table if exists wnprc.animal_requests add column contacts text;

--- a/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.006-21.007.sql
+++ b/WNPRC_EHR/resources/schemas/dbscripts/postgresql/wnprc-21.006-21.007.sql
@@ -1,0 +1,5 @@
+alter table wnprc.animal_requests add column pregnantanimalsrequiredterminfant varchar(100);
+alter table wnprc.animal_requests add column pregnantanimalsrequiredtermdam varchar(100);
+alter table wnprc.animal_requests add column majorsurgery varchar(100);
+alter table wnprc.animal_requests add column previousexposures text;
+alter table wnprc.animal_requests add column contacts text;

--- a/WNPRC_EHR/resources/schemas/wnprc.xml
+++ b/WNPRC_EHR/resources/schemas/wnprc.xml
@@ -280,4 +280,42 @@
             <column columnName="modified"/>
         </columns>
     </table>
+    <table tableName="arrow_protocols" tableDbType="TABLE">
+        <columns>
+            <column columnName="rowid"/>
+            <column columnName="protocol_id"/>
+            <column columnName="protocol_title"/>
+            <column columnName="pi_name"/>
+            <column columnName="date_approved"/>
+            <column columnName="date_expiration"/>
+            <column columnName="date_modified"/>
+            <column columnName="arrow_common_name"/>
+            <column columnName="max_three_year"/>
+            <column columnName="usda_code"/>
+            <column columnName="container"/>
+            <column columnName="createdby"/>
+            <column columnName="created"/>
+            <column columnName="modifiedby"/>
+            <column columnName="modified"/>
+        </columns>
+    </table>
+    <table tableName="extra_protocols" tableDbType="TABLE">
+        <columns>
+            <column columnName="rowid"/>
+            <column columnName="protocol_id"/>
+            <column columnName="protocol_title"/>
+            <column columnName="pi_name"/>
+            <column columnName="date_approved"/>
+            <column columnName="date_expiration"/>
+            <column columnName="date_modified"/>
+            <column columnName="arrow_common_name"/>
+            <column columnName="max_three_year"/>
+            <column columnName="usda_code"/>
+            <column columnName="container"/>
+            <column columnName="createdby"/>
+            <column columnName="created"/>
+            <column columnName="modifiedby"/>
+            <column columnName="modified"/>
+        </columns>
+    </table>
 </tables>

--- a/WNPRC_EHR/resources/schemas/wnprc.xml
+++ b/WNPRC_EHR/resources/schemas/wnprc.xml
@@ -190,6 +190,11 @@
             <column columnName="optionalproject"/>
             <column columnName="internalthreadrowid"/>
             <column columnName="externalthreadrowid"/>
+            <column columnName="pregnantanimalsrequiredterminfant"/>
+            <column columnName="pregnantanimalsrequiredtermdam"/>
+            <column columnName="majorsurgery"/>
+            <column columnName="previousexposures"/>
+            <column columnName="contacts"/>
         </columns>
     </table>
     <table tableName="gestational_days" tableDbType="TABLE">

--- a/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
+++ b/WNPRC_EHR/src/org/labkey/wnprc_ehr/WNPRC_EHRModule.java
@@ -179,7 +179,7 @@ public class WNPRC_EHRModule extends ExtendedSimpleModule
 
     @Override
     public @Nullable Double getSchemaVersion() {
-        return forceUpdate ? Double.POSITIVE_INFINITY : 21.006;
+        return forceUpdate ? Double.POSITIVE_INFINITY : 21.007;
     }
 
     @Override

--- a/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
+++ b/WNPRC_EHR/test/src/org/labkey/test/tests/wnprc_ehr/WNPRC_EHRTest.java
@@ -2848,9 +2848,13 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         fillAnInputByName("mhctype", "2");
         fillAnInputByName("viralstatus", "SPF4");
         fillAnInputByName("infectiousdisease", "Yes");
+        fillAnInputByName("majorsurgery", "Yes");
         fillAnInputByName("pregnantanimalsrequired", "Yes");
+        fillAnInputByName("pregnantanimalsrequiredterminfant", "Yes");
+        fillAnInputByName("pregnantanimalsrequiredtermdam", "Yes");
         fillAnInputByName("disposition", "Terminal");
         fillAnInputByName("executivecommitteeapproval", "Yes");
+        fillAnInputByName("previousexposures", "None");
         fillAnInputByName("optionalproject", "TBD");
         fillAnInputByName("account", "80085");
         fillAnInputByName("protocol", "TBD");
@@ -2861,6 +2865,7 @@ public class WNPRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnl
         el.sendKeys("2022-02-11");
         el.sendKeys(Keys.TAB);
         fillAnInputByName("comments", "test");
+        fillAnInputByName("contacts", "test@test.com");
 
         clickAndWait(Locator.tagWithId("button","submit-final"));
         assertTextPresent("Data Entry");


### PR DESCRIPTION
#### Rationale
Adds additional fields to the animal request form for the assigns group and splits the data entry form into two columns to use more screen real estate since the number of fields is growing large.

#### Related Pull Requests
* [#315](https://github.com/WNPRC-EHR-Services/wnprc-modules/pull/315)

#### Changes
* Adds 5 new fields
* Splits form into two columns
