### PR TITLE
Fix for animal request project # updates

### DIFF
--- a/WNPRC_EHR/resources/queries/wnprc/animal_requests.js
+++ b/WNPRC_EHR/resources/queries/wnprc/animal_requests.js
@@ -16,9 +16,16 @@ function beforeInsert(row, errors){
 }
 
 function onUpsert(helper, scriptErrors, row, oldRow){
-    //updates the project field if its an actual project
-    if (!isNaN(row.optionalproject)){
-        row.project = row.optionalproject
+
+    //only do this operation for an insert (oldRow is blank)
+    if (typeof(oldRow) == 'undefined') {
+        if (!!row.optionalproject && typeof(row.project) == 'undefined'){
+            //if the optional project is something other than a number (TBD) then we need to leave project blank
+            // because the ehr triggers.js requires it to be a number.
+            if (!isNaN(row.optionalproject)){
+                row.project = row.optionalproject
+            }
+        }
     }
 
     //sanity checks for date fields


### PR DESCRIPTION
#### Rationale
The trigger script was resetting the project on form updates to the optionalproject field which gets set on insert mode. It is needed to allow TBD submission.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update animal request trigger script to set the project on insert
